### PR TITLE
Ticker population: add S&P 500 and quarterly refresh

### DIFF
--- a/src/market_data/fetch_tickers.py
+++ b/src/market_data/fetch_tickers.py
@@ -1,12 +1,11 @@
 """
 fetch_tickers.py
 ----------------
-Downloads the current Russell 2000 constituent list from the iShares IWM ETF
-holdings page and saves it as tickers.csv, sorted by market value descending
-(largest market cap first).
+Downloads the current Russell 2000 (IWM) and S&P 500 (IVV) constituent lists
+from the iShares ETF holdings pages and saves a combined tickers.csv, sorted by
+market value descending (largest market cap first).
 
-iShares publishes a daily CSV of all IWM holdings — no login required.
-IWM tracks the Russell 2000 index exactly.
+iShares publishes a daily CSV of all ETF holdings — no login required.
 
 Usage:
     python fetch_tickers.py
@@ -16,16 +15,23 @@ Usage:
 import argparse
 import io
 import sys
+from datetime import date
 from pathlib import Path
 
 import pandas as pd
 import requests
 
-# iShares IWM holdings CSV endpoint (no auth required)
+# iShares ETF holdings CSV endpoints (no auth required)
 IWM_CSV_URL = (
     "https://www.ishares.com/us/products/239710/"
     "ishares-russell-2000-etf/1467271812596.ajax"
     "?fileType=csv&fileName=IWM_holdings&dataType=fund"
+)
+
+IVV_CSV_URL = (
+    "https://www.ishares.com/us/products/239726/"
+    "ishares-core-sp-500-etf/1467271812596.ajax"
+    "?fileType=csv&fileName=IVV_holdings&dataType=fund"
 )
 
 HEADERS = {
@@ -37,9 +43,9 @@ HEADERS = {
 }
 
 
-def fetch_iwm_holdings(url: str = IWM_CSV_URL) -> pd.DataFrame:
-    """Download the IWM holdings CSV and return a cleaned DataFrame."""
-    print(f"Downloading IWM holdings from iShares...")
+def fetch_etf_holdings(url: str) -> pd.DataFrame:
+    """Download an iShares ETF holdings CSV and return the raw DataFrame."""
+    print(f"Downloading ETF holdings from {url[:60]}...")
     resp = requests.get(url, headers=HEADERS, timeout=30)
     resp.raise_for_status()
 
@@ -54,7 +60,7 @@ def fetch_iwm_holdings(url: str = IWM_CSV_URL) -> pd.DataFrame:
 
     if header_idx is None:
         raise ValueError(
-            "Could not locate the 'Ticker' header row in the IWM CSV. "
+            "Could not locate the 'Ticker' header row in the ETF CSV. "
             "The iShares page format may have changed."
         )
 
@@ -64,10 +70,12 @@ def fetch_iwm_holdings(url: str = IWM_CSV_URL) -> pd.DataFrame:
     return df
 
 
-def clean_holdings(df: pd.DataFrame) -> pd.DataFrame:
+def clean_holdings(df: pd.DataFrame, index_label: str) -> pd.DataFrame:
     """
     Normalize column names, drop non-equity rows (cash, futures, etc.),
-    parse market value, and sort by market value descending.
+    parse market value, tag the index, and sort by market value descending.
+
+    Returns a DataFrame with columns: symbol, name, market_value, index.
     """
     df.columns = [c.strip() for c in df.columns]
 
@@ -96,11 +104,135 @@ def clean_holdings(df: pd.DataFrame) -> pd.DataFrame:
         .reset_index(drop=True)
     )
 
+    result["index"] = index_label
+
+    return result
+
+
+def _combine_index_labels(labels: pd.Series) -> str:
+    """Aggregate helper: if both SP500 and RUT2000 are present, combine them."""
+    unique = set(labels)
+    if "SP500" in unique and "RUT2000" in unique:
+        return "SP500,RUT2000"
+    return labels.iloc[0]
+
+
+def merge_holdings(iwm_df: pd.DataFrame, ivv_df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Merge IWM (Russell 2000) and IVV (S&P 500) holdings into a single DataFrame.
+
+    For tickers appearing in both:
+      - index = "SP500,RUT2000"
+      - market_value = max of the two values
+      - name = from the row with the higher market_value
+
+    Returns columns: symbol, name, market_value, index — sorted by market_value desc.
+    """
+    merged = (
+        pd.concat([iwm_df, ivv_df], ignore_index=True)
+        .sort_values("market_value", ascending=False)  # first() picks higher-cap name
+        .groupby("symbol", sort=False)
+        .agg(
+            name=("name", "first"),
+            market_value=("market_value", "max"),
+            index=("index", _combine_index_labels),
+        )
+        .reset_index()
+        .sort_values("market_value", ascending=False)
+        .reset_index(drop=True)
+    )
+    return merged
+
+
+def apply_date_added(
+    new_df: pd.DataFrame,
+    existing_path: Path,
+    today: str,
+) -> pd.DataFrame:
+    """
+    Assign a date_added column to new_df by merging with an existing tickers.csv.
+
+    Rules:
+    - New tickers (not in existing file) get date_added = today.
+    - Existing tickers keep their original date_added.
+    - Tickers that dropped out of both indices are carried forward unchanged
+      (avoids survivorship bias).
+    - Backward-compat backfill: if existing file has no date_added column,
+      all its rows get "2000-01-01"; if no index column, they get "RUT2000".
+    """
+    if not existing_path.exists():
+        new_df = new_df.copy()
+        new_df["date_added"] = today
+        return new_df
+
+    existing_df = pd.read_csv(existing_path, dtype=str)
+
+    # Backward-compat backfill for old schema
+    if "date_added" not in existing_df.columns:
+        existing_df["date_added"] = "2000-01-01"
+    if "index" not in existing_df.columns:
+        existing_df["index"] = "RUT2000"
+
+    # Build lookup: symbol -> date_added from existing file
+    known = dict(zip(existing_df["symbol"], existing_df["date_added"]))
+
+    # Assign date_added: preserve existing dates, new tickers get today
+    new_df = new_df.copy()
+    new_df["date_added"] = new_df["symbol"].map(known).fillna(today)
+
+    # Carry forward any tickers that dropped out of both indices
+    new_symbols = set(new_df["symbol"])
+    dropped = existing_df[~existing_df["symbol"].isin(new_symbols)].copy()
+
+    if not dropped.empty:
+        # Ensure dropped rows have the same columns as new_df
+        for col in new_df.columns:
+            if col not in dropped.columns:
+                dropped[col] = None
+        dropped = dropped[new_df.columns]
+        # market_value may be string from read_csv; coerce
+        dropped["market_value"] = pd.to_numeric(dropped["market_value"], errors="coerce")
+
+    result = (
+        pd.concat([new_df, dropped], ignore_index=True)
+        .drop_duplicates(subset=["symbol"], keep="first")
+        .sort_values("market_value", ascending=False, na_position="last")
+        .reset_index(drop=True)
+    )
+
+    return result
+
+
+def run(out_path: Path, today: str | None = None) -> pd.DataFrame:
+    """
+    Fetch IWM + IVV holdings, merge, apply date_added logic, and write tickers.csv.
+    Returns the final DataFrame.
+    """
+    if today is None:
+        today = date.today().isoformat()
+
+    raw_iwm = fetch_etf_holdings(IWM_CSV_URL)
+    raw_ivv = fetch_etf_holdings(IVV_CSV_URL)
+
+    iwm = clean_holdings(raw_iwm, "RUT2000")
+    ivv = clean_holdings(raw_ivv, "SP500")
+
+    merged = merge_holdings(iwm, ivv)
+    result = apply_date_added(merged, out_path, today)
+
+    if result.empty:
+        raise ValueError("No tickers after merging — CSV format may have changed.")
+
+    result[["symbol", "name", "market_value", "index", "date_added"]].to_csv(
+        out_path, index=False
+    )
     return result
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Fetch Russell 2000 tickers from iShares IWM.")
+    parser = argparse.ArgumentParser(
+        description="Fetch Russell 2000 (IWM) + S&P 500 (IVV) tickers from iShares."
+    )
     parser.add_argument(
         "--out",
         default="tickers.csv",
@@ -111,19 +243,16 @@ def main() -> None:
     out_path = Path(args.out)
 
     try:
-        raw = fetch_iwm_holdings()
+        tickers = run(out_path)
     except requests.RequestException as exc:
-        print(f"ERROR: Failed to download IWM holdings: {exc}", file=sys.stderr)
+        print(f"ERROR: Failed to download ETF holdings: {exc}", file=sys.stderr)
         sys.exit(1)
 
-    tickers = clean_holdings(raw)
-
-    if tickers.empty:
-        print("ERROR: No tickers found after cleaning — the CSV format may have changed.", file=sys.stderr)
-        sys.exit(1)
-
-    tickers.to_csv(out_path, index=False)
-    print(f"Saved {len(tickers)} tickers to {out_path}")
+    counts = tickers["index"].value_counts()
+    print(f"\nSaved {len(tickers)} tickers to {out_path}")
+    for label, count in counts.items():
+        print(f"  {label}: {count}")
+    print()
     print(tickers.head(10).to_string(index=False))
 
 

--- a/src/market_data/orchestrator.py
+++ b/src/market_data/orchestrator.py
@@ -44,6 +44,7 @@ DATA_DIR = Path("data")
 
 DEFAULT_BATCH_SIZE = 50
 SLEEP_BETWEEN_CALLS = 5  # seconds; be polite to the yfinance endpoint
+TICKER_REFRESH_DAYS = 90
 
 
 # ---------------------------------------------------------------------------
@@ -56,12 +57,47 @@ def load_state() -> dict:
         return {
             "onboarded": raw.get("onboarded", []),
             "last_run": raw.get("last_run"),
+            "last_ticker_refresh": raw.get("last_ticker_refresh"),
         }
-    return {"onboarded": [], "last_run": None}
+    return {"onboarded": [], "last_run": None, "last_ticker_refresh": None}
 
 
 def save_state(state: dict) -> None:
     STATE_FILE.write_text(json.dumps(state, indent=2, default=str))
+
+
+# ---------------------------------------------------------------------------
+# Ticker list refresh
+# ---------------------------------------------------------------------------
+
+def maybe_refresh_tickers(
+    state: dict,
+    tickers_path: Path,
+    today: date,
+) -> bool:
+    """
+    Refresh tickers.csv if last_ticker_refresh is absent or >90 days ago.
+    Returns True if a refresh was performed.
+
+    Failures are non-fatal: if the iShares site is down, the pipeline continues
+    with the existing tickers.csv and logs a warning.
+    """
+    last_raw = state.get("last_ticker_refresh")
+    if last_raw:
+        days_since = (today - date.fromisoformat(last_raw)).days
+        if days_since < TICKER_REFRESH_DAYS:
+            print(f"  Ticker list is fresh ({days_since}d old, threshold {TICKER_REFRESH_DAYS}d)")
+            return False
+
+    print(f"\nRefreshing ticker list (last refresh: {last_raw or 'never'})...")
+    try:
+        from market_data import fetch_tickers  # noqa: PLC0415
+        fetch_tickers.run(tickers_path, today=today.isoformat())
+        print("  Ticker list refreshed successfully.")
+        return True
+    except Exception as exc:
+        print(f"  WARNING: Ticker refresh failed: {exc}. Continuing with existing list.")
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -182,14 +218,18 @@ def run(batch_size: int, skip_update: bool, run_merge: bool) -> None:
         date.fromisoformat(state["last_run"]) if state["last_run"] else None
     )
 
+    # --- 0. Auto-refresh ticker list if stale ---
+    refreshed = maybe_refresh_tickers(state, TICKERS_FILE, today)
+
     all_tickers = load_ordered_tickers()
     pending = [t for t in all_tickers if t not in onboarded]
 
     print(f"\nmarket_data orchestrator  —  {today}")
-    print(f"  Tickers in list : {len(all_tickers)}")
+    print(f"  Tickers in list  : {len(all_tickers)}")
     print(f"  Already onboarded: {len(onboarded)}")
     print(f"  Pending          : {len(pending)}")
     print(f"  Last run         : {last_run or 'never'}")
+    print(f"  Last ticker refresh: {state.get('last_ticker_refresh') or 'never'}")
 
     # --- 1. Onboard new tickers ---
     newly_onboarded, _failed = step_onboard(pending, batch_size, onboarded)
@@ -207,6 +247,8 @@ def run(batch_size: int, skip_update: bool, run_merge: bool) -> None:
     # --- 3. Persist state ---
     state["onboarded"] = sorted(onboarded)
     state["last_run"] = str(today)
+    if refreshed:
+        state["last_ticker_refresh"] = str(today)
     save_state(state)
 
     # --- 4. Summary ---


### PR DESCRIPTION
## Summary
- Expands ticker coverage from Russell 2000 only to Russell 2000 + S&P 500 by fetching both iShares IWM and IVV ETF holdings
- Adds `index` and `date_added` columns to `tickers.csv`; tickers in both indices are labelled `SP500,RUT2000`
- Dropped tickers are carried forward in `tickers.csv` to avoid survivorship bias in backtests
- Orchestrator auto-refreshes the ticker list every 90 days; refresh failures are non-fatal

## Test plan
- [ ] Run `market-data-fetch-tickers --out test.csv` and verify ~2200-2400 rows, 5 columns, and some `SP500,RUT2000` entries
- [ ] Re-run and confirm `date_added` values are unchanged (idempotent)
- [ ] Set `last_ticker_refresh` to `"2025-12-01"` in `state.json`, run `market-data-run --batch-size 0 --no-update`, verify refresh fires and `last_ticker_refresh` updates to today
- [ ] Run again immediately and confirm "Ticker list is fresh" with no second refresh
- [ ] Confirm existing `tickers.csv` without `index`/`date_added` columns is backfilled gracefully