### PR TITLE
Data collection expansion: indices, macro, fundamentals, options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Secrets — never commit
+.env
+
 # Virtual environment
 .venv/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,99 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+---
+
+## [0.2.4] — 2026-04-05
+
+### Added
+- `fetch_options.py` — daily option chain snapshots for SP500 tickers via yfinance:
+  - Collects nearest 4 expiration dates per ticker (configurable via `--max-expiries`)
+  - Fields per contract: `snapshot_date`, `symbol`, `expiry`, `strike`, `option_type`,
+    `last_price`, `bid`, `ask`, `volume`, `open_interest`, `implied_vol`, `in_the_money`
+  - Batched across days (default 50 tickers/run, ~10-day cycle for full SP500 coverage)
+  - Cycle state tracked in `state.json` under `options_cycle`; auto-resets when all SP500
+    tickers have been covered
+  - Stores data in `data/options/<SYMBOL>.parquet`; deduped on
+    `(snapshot_date, symbol, expiry, strike, option_type)`
+  - CLI flags: `--batch-size`, `--max-expiries`, `--symbols`
+- `market-data-fetch-options` — new CLI entry point
+- `--options` and `--options-batch-size` flags added to `market-data-run` orchestrator
+- `options_cycle` added to `state.json` schema
+- `run_and_sleep.bat` updated to include `--options` in the daily run
+
+### Notes
+- yfinance option chains are an unofficial scraper; Greek values (delta, gamma, theta,
+  vega) are not available. Implied volatility is available but carries the same
+  reliability caveat. Suitable for research and forecasting, not production trading.
+
+---
+
+## [0.2.3] — 2026-04-05
+
+### Added
+- `fetch_fundamentals.py` — monthly per-ticker fundamental snapshots via yfinance `.info`:
+  - Valuation: `market_cap`, `enterprise_value`, `trailing_pe`, `forward_pe`, `price_to_book`
+  - Earnings & revenue: `trailing_eps`, `forward_eps`, `total_revenue`, `profit_margin`
+  - Analyst estimates: `analyst_target_mean/low/high`, `analyst_recommendation`, `analyst_count`
+  - Each run appends one row tagged with `as_of` date; deduped on `(as_of, symbol)`
+  - Stores data in `data/fundamentals/<SYMBOL>.parquet`
+  - Standalone CLI defaults to all tickers in `state.json`; accepts `--symbols` override
+- `market-data-fetch-fundamentals` — new CLI entry point
+- `--fundamentals` flag added to `market-data-run` orchestrator
+  - Auto-skipped if last fundamentals run was <30 days ago (same pattern as ticker refresh)
+  - `last_fundamentals_run` persisted in `state.json`
+
+---
+
+## [0.2.2] — 2026-04-05
+
+### Added
+- `fetch_macro.py` — collects macroeconomic time series from the FRED API:
+  - 10 series configured by default (daily, monthly, and quarterly):
+    - `DFF` — Effective Federal Funds Rate
+    - `T10Y2Y` — 10-year minus 2-year Treasury yield spread
+    - `CPIAUCSL` — CPI headline
+    - `CPILFESL` — Core CPI (ex food & energy)
+    - `PCEPI` — PCE Price Index
+    - `PCEPILFE` — Core PCE
+    - `UNRATE` — Unemployment Rate
+    - `PAYEMS` — Nonfarm Payrolls
+    - `GDPC1` — Real GDP (chained 2017 dollars)
+    - `GDP` — Nominal GDP
+  - Bootstraps from 1990-01-01 on first run; incremental updates thereafter
+  - 7-day lookback on incremental pulls to capture FRED data revisions
+  - Stores data in `data/macro/<SERIES_ID>.parquet` with schema `date, series_id, value`
+  - Reads `FRED_API_KEY` from `.env` via `python-dotenv`
+  - CLI flags: `--series`, `--start`
+- `market-data-fetch-macro` — new CLI entry point
+- `--macro` flag added to `market-data-run` orchestrator
+- `fredapi>=0.5` and `python-dotenv>=1.0` added to dependencies
+- `.env` — project-root secrets file for API keys (gitignored)
+- `.env` added to `.gitignore`
+
+---
+
+## [0.2.1] — 2026-04-05
+
+### Added
+- `fetch_indices.py` — collects daily OHLCV data for market index and rate symbols:
+  - `^VIX` — CBOE Volatility Index
+  - `^TNX` — 10-year Treasury yield
+  - `^TYX` — 30-year Treasury yield
+  - `^FVX` — 5-year Treasury yield
+  - `^IRX` — 13-week T-bill yield
+  - `ZQ=F` — 30-day Fed Funds Futures (front month)
+  - `^GSPC` — S&P 500 index level
+  - Bootstraps full history on first run; incremental updates thereafter
+  - Stores data in `data/indices/<SYMBOL>.parquet` (same schema as equity OHLCV)
+  - CLI flags: `--history`, `--symbols`
+- `market-data-fetch-indices` — new CLI entry point
+- `--indices` flag added to `market-data-run` orchestrator
+
+---
+
+## [0.1.0] — 2026-04-04
+
 ### Added
 - `fetch_tickers.py` — downloads current Russell 2000 constituents from the
   iShares IWM ETF holdings CSV; saves `tickers.csv` sorted by market value

--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # market_data
 
-Daily OHLCV data collector for the `paper_trading` backtest engine.
+Market data collector for the `paper_trading` backtest engine.
 
-Pulls historical and incremental data for Russell 2000 tickers via yfinance,
-stores per-ticker Parquet files, and produces a merged Parquet ready for the
-backtest engine.
+Collects and stores four categories of data:
+
+| Category | Source | Cadence | Storage |
+|----------|--------|---------|---------|
+| Equity OHLCV (SP500 + Russell 2000) | yfinance | Daily | `data/<SYMBOL>.parquet` |
+| Market indices & rates (VIX, Treasury yields, Fed Funds futures) | yfinance | Daily | `data/indices/<SYMBOL>.parquet` |
+| Macro series (CPI, GDP, unemployment, etc.) | FRED API | Daily/Monthly/Quarterly | `data/macro/<SERIES_ID>.parquet` |
+| Per-ticker fundamentals (market cap, analyst estimates) | yfinance | Monthly | `data/fundamentals/<SYMBOL>.parquet` |
+| Options chains / IV (SP500 only) | yfinance | Daily (batched ~10-day cycle) | `data/options/<SYMBOL>.parquet` |
 
 ---
 
@@ -15,9 +21,13 @@ virtual environment:
 
 | Command | Description |
 |---------|-------------|
-| `market-data-fetch-tickers` | Download the current Russell 2000 constituent list and save to `tickers.csv` |
-| `market-data-run` | Run the daily pipeline — onboard new tickers and update existing ones |
-| `market-data-merge` | Merge all per-ticker Parquet files into a single `data/merged.parquet` |
+| `market-data-fetch-tickers` | Download the current Russell 2000 + SP500 constituent list and save to `tickers.csv` |
+| `market-data-run` | Run the daily pipeline — onboard new tickers, update existing ones, and optionally run all data types |
+| `market-data-merge` | Merge all per-ticker OHLCV Parquet files into a single `data/merged.parquet` |
+| `market-data-fetch-indices` | Update market index and rate symbols (VIX, Treasury yields, Fed Funds futures) |
+| `market-data-fetch-macro` | Update FRED macro series (CPI, GDP, Fed Funds rate, Treasury spread, etc.) |
+| `market-data-fetch-fundamentals` | Snapshot per-ticker fundamentals for all onboarded tickers (market cap, analyst targets, etc.) |
+| `market-data-fetch-options` | Run the next batch of SP500 option chain snapshots (IV, bid/ask, open interest) |
 
 Each command accepts `--help` for full usage details.
 
@@ -33,36 +43,32 @@ Install as an editable package (recommended — registers the CLI commands):
 pip install -e .
 ```
 
-Or install dependencies only:
+### 2. Set up API keys
 
-```bash
-pip install -r requirements.txt
+Create a `.env` file at the project root with your FRED API key
+(free at https://fred.stlouisfed.org/):
+
+```
+FRED_API_KEY=your_key_here
 ```
 
-### 2. Generate the ticker list
+The `.env` file is gitignored. yfinance requires no API key.
 
-Fetches the current Russell 2000 constituents from the iShares IWM ETF
-holdings page (no API key required) and saves them to `tickers.csv`, sorted
-by market value largest-first.
+### 3. Generate the ticker list
+
+Fetches the current Russell 2000 and S&P 500 constituents from iShares ETF
+holdings (no API key required) and saves them to `tickers.csv`, sorted by
+market value largest-first.
 
 ```bash
 market-data-fetch-tickers
-```
-
-Expected output:
-```
-Downloading IWM holdings from iShares...
-Saved 1933 tickers to tickers.csv
-symbol                               name  market_value
-    BE          BLOOM ENERGY CLASS A CORP  703904509.44
-   ...
 ```
 
 Re-run this periodically to pick up index additions. New tickers will
 automatically be queued for historical backfill the next time the
 orchestrator runs.
 
-### 3. Run the orchestrator
+### 4. Run the orchestrator
 
 The orchestrator handles both historical backfill and daily incremental updates
 in a single run. On each execution it:
@@ -75,19 +81,31 @@ in a single run. On each execution it:
 Progress is saved to `state.json` so runs are safe to interrupt and resume.
 
 ```bash
-market-data-run                        # onboard next 50 tickers + update existing
-market-data-run --batch-size 25        # onboard fewer new tickers per day
-market-data-run --batch-size 0         # skip onboarding; updates only
-market-data-run --no-update            # skip updates; onboard only
-market-data-run --merge                # auto-run merge when done
+market-data-run                                          # onboard + update OHLCV only
+market-data-run --indices                                # also update indices & rates
+market-data-run --macro                                  # also update FRED macro series
+market-data-run --fundamentals                           # also snapshot fundamentals (monthly)
+market-data-run --indices --macro --fundamentals --options --merge # full run (recommended daily)
+market-data-run --batch-size 25                          # onboard fewer new tickers per day
+market-data-run --batch-size 0                           # skip onboarding; updates only
+market-data-run --no-update                              # skip updates; onboard only
 ```
 
-At 50 tickers/day the full Russell 2000 takes ~40 days to onboard.
+At 50 tickers/day the full SP500 + Russell 2000 list takes ~60 days to onboard.
 
-### 4. Merge into a single file
+### 5. Bootstrap supplemental data
 
-Once you have data for the tickers you want, merge them into a single Parquet
-for the backtest engine:
+On first setup, run each supplemental command once to pull full history:
+
+```bash
+market-data-fetch-indices               # 10 years of VIX, Treasury yields, etc.
+market-data-fetch-macro                 # FRED series back to 1990-01-01
+market-data-fetch-fundamentals          # current snapshot for all onboarded tickers
+```
+
+### 6. Merge into a single file
+
+Merge all per-ticker OHLCV files into a single Parquet for the backtest engine:
 
 ```bash
 market-data-merge
@@ -96,23 +114,34 @@ market-data-merge
 This writes `data/merged.parquet`. Pass `--merge` to the orchestrator to do
 this automatically at the end of each run.
 
-### 5. Schedule daily runs
+### 7. Schedule daily runs
 
-Use Windows Task Scheduler to run `orchestrator.py` once per day. Point it
-at your Python interpreter and this project directory.
+`run_and_sleep.bat` activates the virtual environment, runs the full pipeline,
+logs output to `logs/runner.log`, and hibernates the PC. Point Windows Task
+Scheduler at it:
 
-Example task action:
 ```
-Program:   C:\path\to\.venv\Scripts\market-data-run.exe
-Arguments: --merge
+Program:   C:\Windows\System32\cmd.exe
+Arguments: /c D:\market_data\run_and_sleep.bat
 Start in:  D:\market_data
 ```
 
+The batch file runs:
+```
+market-data-run --indices --macro --fundamentals --options --merge
+```
+
+`--fundamentals` is self-throttling — it auto-skips if a snapshot was taken
+less than 30 days ago, so it's safe to include in every daily run.
+
+`--options` processes the next 50 SP500 tickers in the current cycle. After
+all ~500 SP500 tickers are covered (~10 days), the cycle resets automatically.
+
 ---
 
-## Data format
+## Data formats
 
-Per-ticker files are stored in `data/<SYMBOL>.parquet` with columns:
+### Equity OHLCV — `data/<SYMBOL>.parquet`
 
 | Column | Type | Notes |
 |--------|------|-------|
@@ -124,8 +153,8 @@ Per-ticker files are stored in `data/<SYMBOL>.parquet` with columns:
 | `close` | float | Adjusted close |
 | `volume` | float | |
 
-The merged file (`data/merged.parquet`) is the file you pass to the
-`paper_trading` backtest engine:
+`data/merged.parquet` is a concatenation of all per-ticker files, used as the
+input to the `paper_trading` backtest engine:
 
 ```python
 from paper_trading import MarketData, BacktestEngine
@@ -133,3 +162,86 @@ from paper_trading import MarketData, BacktestEngine
 md = MarketData.from_parquet("../market_data/data/merged.parquet")
 engine = BacktestEngine(market_data=md, initial_cash=100_000)
 ```
+
+### Indices & rates — `data/indices/<SYMBOL>.parquet`
+
+Same schema as equity OHLCV. Symbols collected:
+
+| Symbol | Description |
+|--------|-------------|
+| `^VIX` | CBOE Volatility Index |
+| `^TNX` | 10-year Treasury yield |
+| `^TYX` | 30-year Treasury yield |
+| `^FVX` | 5-year Treasury yield |
+| `^IRX` | 13-week T-bill yield |
+| `ZQ=F` | 30-day Fed Funds Futures (front month) |
+| `^GSPC` | S&P 500 index level |
+
+### Macro series — `data/macro/<SERIES_ID>.parquet`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `date` | date | Observation date |
+| `series_id` | str | FRED series ID |
+| `value` | float | |
+
+Series collected by default:
+
+| Series ID | Description | Frequency |
+|-----------|-------------|-----------|
+| `DFF` | Effective Federal Funds Rate | Daily |
+| `T10Y2Y` | 10yr minus 2yr Treasury spread | Daily |
+| `CPIAUCSL` | CPI — All Urban (headline) | Monthly |
+| `CPILFESL` | Core CPI (ex food & energy) | Monthly |
+| `PCEPI` | PCE Price Index | Monthly |
+| `PCEPILFE` | Core PCE | Monthly |
+| `UNRATE` | Unemployment Rate | Monthly |
+| `PAYEMS` | Nonfarm Payrolls | Monthly |
+| `GDPC1` | Real GDP (chained 2017 dollars) | Quarterly |
+| `GDP` | Nominal GDP | Quarterly |
+
+### Options chains — `data/options/<SYMBOL>.parquet`
+
+Daily snapshots for SP500 tickers. Each row is one option contract observed on `snapshot_date`.
+
+| Column | Description |
+|--------|-------------|
+| `snapshot_date` | Date the snapshot was taken |
+| `symbol` | Underlying ticker |
+| `expiry` | Option expiration date |
+| `strike` | Strike price |
+| `option_type` | `"call"` or `"put"` |
+| `last_price` | Last traded price |
+| `bid` | Bid price |
+| `ask` | Ask price |
+| `volume` | Contracts traded on snapshot date |
+| `open_interest` | Total open contracts |
+| `implied_vol` | Implied volatility (annualised decimal, e.g. 0.25 = 25%) |
+| `in_the_money` | `True` if the contract is currently ITM |
+
+Covers the nearest 4 expiration dates per ticker. Data source is yfinance
+(unofficial scraper) — suitable for research and forecasting, not production trading.
+Greek values (delta, gamma, etc.) are not available from this source.
+
+### Fundamentals — `data/fundamentals/<SYMBOL>.parquet`
+
+One row per ticker per monthly snapshot, tagged with `as_of` date.
+
+| Column | Description |
+|--------|-------------|
+| `as_of` | Snapshot date |
+| `symbol` | Ticker symbol |
+| `market_cap` | Market capitalisation |
+| `enterprise_value` | Enterprise value |
+| `trailing_pe` | Trailing P/E ratio |
+| `forward_pe` | Forward P/E ratio |
+| `price_to_book` | Price-to-book ratio |
+| `trailing_eps` | EPS (trailing 12 months) |
+| `forward_eps` | EPS (forward estimate) |
+| `total_revenue` | Revenue (trailing 12 months) |
+| `profit_margin` | Net profit margin |
+| `analyst_target_mean` | Analyst mean price target |
+| `analyst_target_low` | Analyst low price target |
+| `analyst_target_high` | Analyst high price target |
+| `analyst_recommendation` | Mean recommendation (1=Strong Buy … 5=Strong Sell) |
+| `analyst_count` | Number of analyst opinions |

--- a/backlog.md
+++ b/backlog.md
@@ -23,6 +23,16 @@ Wishlist items — not needed for MVP. Revisit when the core pipeline is stable.
     trading day
   - Tag each ticker row with whether it was in the index on that date
 
+## Options & Implied Volatility
+
+- **Upgrade options source (post Phase 4)**
+  The current `fetch_options.py` uses yfinance (unofficial scraper). If data
+  quality becomes an issue, consider upgrading to:
+  - Alpaca paid tier — provides real option chains with accurate IV and Greeks
+  - CBOE DataShop — official source for historical options data
+  Greek values (delta, gamma, theta, vega) are not available from yfinance
+  and would require a paid source.
+
 ## Scheduling & Orchestration
 
 - **Automated scheduler**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "market_data"
-version = "0.1.0"
-description = "Daily OHLCV data collector for the paper_trading backtest engine."
+version = "0.2.4"
+description = "Market data collector for the paper_trading backtest engine."
 requires-python = ">=3.10"
 license = { text = "MIT" }
 dependencies = [
@@ -13,12 +13,18 @@ dependencies = [
   "pandas>=2.0",
   "pyarrow>=14.0",
   "requests>=2.31",
+  "fredapi>=0.5",
+  "python-dotenv>=1.0",
 ]
 
 [project.scripts]
-market-data-fetch-tickers = "market_data.fetch_tickers:main"
-market-data-run           = "market_data.orchestrator:main"
-market-data-merge         = "market_data.merge:main"
+market-data-fetch-tickers  = "market_data.fetch_tickers:main"
+market-data-run            = "market_data.orchestrator:main"
+market-data-merge          = "market_data.merge:main"
+market-data-fetch-indices       = "market_data.fetch_indices:main"
+market-data-fetch-macro         = "market_data.fetch_macro:main"
+market-data-fetch-fundamentals  = "market_data.fetch_fundamentals:main"
+market-data-fetch-options       = "market_data.fetch_options:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ yfinance>=0.2
 pandas>=2.0
 pyarrow>=14.0
 requests>=2.31
+fredapi>=0.5
+python-dotenv>=1.0

--- a/run_and_sleep.bat
+++ b/run_and_sleep.bat
@@ -22,7 +22,12 @@ echo Started: %date% %time% >> %LOG_FILE%
 echo ======================================== >> %LOG_FILE%
 
 :: Run pipeline — stdout and stderr both go to the log
-market-data-run --merge >> %LOG_FILE% 2>&1
+:: --indices     : update VIX, Treasury yields, Fed Funds futures (daily)
+:: --macro       : update FRED macro series — CPI, GDP, etc. (daily, incremental)
+:: --fundamentals: snapshot market cap + analyst data (auto-skipped if <30 days old)
+:: --options     : next batch of SP500 option chains (50 tickers/day, cycles ~10 days)
+:: --merge       : rebuild merged.parquet for the backtest engine
+market-data-run --indices --macro --fundamentals --options --merge >> %LOG_FILE% 2>&1
 
 :: Log finish
 echo ======================================== >> %LOG_FILE%

--- a/src/market_data/fetch_fundamentals.py
+++ b/src/market_data/fetch_fundamentals.py
@@ -1,0 +1,248 @@
+"""
+fetch_fundamentals.py
+---------------------
+Collect point-in-time fundamental snapshots for equity tickers via yfinance.
+
+Each run appends one row per ticker (tagged with today's date as `as_of`) to
+a per-ticker Parquet file under data/fundamentals/<SYMBOL>.parquet.  Over time
+this builds a monthly time series of valuation and analyst-estimate data.
+
+Fields captured
+---------------
+Valuation
+  market_cap            marketCap
+  enterprise_value      enterpriseValue
+  trailing_pe           trailingPE
+  forward_pe            forwardPE
+  price_to_book         priceToBook
+
+Earnings & revenue
+  trailing_eps          trailingEps
+  forward_eps           forwardEps
+  total_revenue         totalRevenue
+  profit_margin         profitMargins
+
+Analyst estimates
+  analyst_target_mean   targetMeanPrice
+  analyst_target_low    targetLowPrice
+  analyst_target_high   targetHighPrice
+  analyst_recommendation  recommendationMean  (1=Strong Buy … 5=Strong Sell)
+  analyst_count         numberOfAnalystOpinions
+
+Usage
+-----
+    market-data-fetch-fundamentals                     # fetch all onboarded tickers
+    market-data-fetch-fundamentals --symbols AAPL MSFT # specific symbols only
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+import yfinance as yf
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+FUNDAMENTALS_DIR = Path("data/fundamentals")
+SLEEP_BETWEEN_CALLS = 2  # seconds — .info is lighter than a full history pull
+
+# Mapping: our column name → yfinance info key
+INFO_FIELDS: dict[str, str] = {
+    # Valuation
+    "market_cap":               "marketCap",
+    "enterprise_value":         "enterpriseValue",
+    "trailing_pe":              "trailingPE",
+    "forward_pe":               "forwardPE",
+    "price_to_book":            "priceToBook",
+    # Earnings & revenue
+    "trailing_eps":             "trailingEps",
+    "forward_eps":              "forwardEps",
+    "total_revenue":            "totalRevenue",
+    "profit_margin":            "profitMargins",
+    # Analyst estimates
+    "analyst_target_mean":      "targetMeanPrice",
+    "analyst_target_low":       "targetLowPrice",
+    "analyst_target_high":      "targetHighPrice",
+    "analyst_recommendation":   "recommendationMean",
+    "analyst_count":            "numberOfAnalystOpinions",
+}
+
+SCHEMA_COLS = ["as_of", "symbol"] + list(INFO_FIELDS.keys())
+
+
+# ---------------------------------------------------------------------------
+# Storage helpers
+# ---------------------------------------------------------------------------
+
+def _path(symbol: str, fund_dir: Path) -> Path:
+    return fund_dir / f"{symbol}.parquet"
+
+
+def load_fundamentals(symbol: str, fund_dir: Path) -> pd.DataFrame | None:
+    path = _path(symbol, fund_dir)
+    if not path.exists():
+        return None
+    return pd.read_parquet(path)
+
+
+def save_fundamentals(symbol: str, record: dict, fund_dir: Path) -> int:
+    """
+    Append one snapshot row to the per-ticker fundamentals Parquet.
+
+    Deduplicates on (as_of, symbol) so re-running on the same day is safe.
+    Returns 1 if a new row was added, 0 if the row already existed.
+    """
+    fund_dir.mkdir(parents=True, exist_ok=True)
+    path = _path(symbol, fund_dir)
+
+    new_row = pd.DataFrame([record])[SCHEMA_COLS]
+    new_row["as_of"] = pd.to_datetime(new_row["as_of"]).dt.date
+
+    if path.exists():
+        existing = pd.read_parquet(path)
+        combined = pd.concat([existing, new_row], ignore_index=True)
+    else:
+        combined = new_row.copy()
+
+    before = len(combined) - len(new_row)
+
+    combined["as_of"] = pd.to_datetime(combined["as_of"]).dt.date
+    combined = (
+        combined
+        .drop_duplicates(subset=["as_of", "symbol"])
+        .sort_values("as_of")
+        .reset_index(drop=True)
+    )
+
+    tmp_path = path.with_suffix(".tmp.parquet")
+    combined.to_parquet(tmp_path, index=False)
+    tmp_path.replace(path)
+
+    return len(combined) - before
+
+
+# ---------------------------------------------------------------------------
+# Fetch
+# ---------------------------------------------------------------------------
+
+def fetch_fundamentals(symbol: str) -> dict | None:
+    """
+    Pull the fundamentals snapshot for `symbol` via yfinance .info.
+
+    Returns a dict ready to pass to save_fundamentals(), or None if the ticker
+    returned no usable data.
+    """
+    try:
+        info = yf.Ticker(symbol).info
+    except Exception:
+        return None
+
+    # Require at least a market cap to consider the record valid
+    if not info.get("marketCap"):
+        return None
+
+    record: dict = {"as_of": date.today(), "symbol": symbol}
+    for col, yf_key in INFO_FIELDS.items():
+        record[col] = info.get(yf_key)  # None if key is missing
+
+    return record
+
+
+# ---------------------------------------------------------------------------
+# Core run logic
+# ---------------------------------------------------------------------------
+
+def run(
+    symbols: list[str],
+    fund_dir: Path = FUNDAMENTALS_DIR,
+) -> None:
+    """
+    Fetch and store a fundamentals snapshot for each symbol in `symbols`.
+    """
+    today = date.today()
+    total = len(symbols)
+
+    print(f"\nmarket_data fundamentals  —  {today}")
+    print(f"  Tickers: {total}")
+    print(f"{'='*55}")
+
+    saved = 0
+    skipped = 0
+    failed = 0
+
+    for i, symbol in enumerate(symbols, 1):
+        prefix = f"  [{i:>4}/{total}] {symbol:<8}"
+        try:
+            record = fetch_fundamentals(symbol)
+            if record is None:
+                print(f"{prefix}  no data")
+                skipped += 1
+            else:
+                added = save_fundamentals(symbol, record, fund_dir)
+                if added:
+                    mktcap = record.get("market_cap")
+                    cap_str = f"  mktcap={mktcap:,.0f}" if mktcap else ""
+                    print(f"{prefix}  saved{cap_str}")
+                    saved += 1
+                else:
+                    print(f"{prefix}  already up to date")
+                    skipped += 1
+        except Exception as exc:
+            print(f"{prefix}  ERROR: {exc}")
+            failed += 1
+
+        if i < total:
+            time.sleep(SLEEP_BETWEEN_CALLS)
+
+    print(f"{'='*55}")
+    print(f"Done.  Saved: {saved}  |  Skipped: {skipped}  |  Failed: {failed}\n")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Fetch fundamental snapshots (market cap, analyst estimates, etc.) "
+            "for equity tickers via yfinance."
+        )
+    )
+    parser.add_argument(
+        "--symbols",
+        nargs="+",
+        metavar="SYMBOL",
+        help=(
+            "Symbols to fetch. Defaults to all tickers in state.json (onboarded list). "
+            "Example: --symbols AAPL MSFT TSLA"
+        ),
+    )
+    args = parser.parse_args()
+
+    if args.symbols:
+        symbols = args.symbols
+    else:
+        # Load from state.json
+        import json  # noqa: PLC0415
+        state_file = Path("state.json")
+        if not state_file.exists():
+            print("No state.json found and no --symbols provided. Nothing to do.")
+            return
+        state = json.loads(state_file.read_text())
+        symbols = sorted(state.get("onboarded", []))
+        if not symbols:
+            print("No onboarded tickers in state.json. Run market-data-run first.")
+            return
+
+    run(symbols=symbols)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/market_data/fetch_indices.py
+++ b/src/market_data/fetch_indices.py
@@ -1,0 +1,142 @@
+"""
+fetch_indices.py
+----------------
+Collect daily OHLCV data for market index and rate symbols.
+
+Covers:
+  ^VIX   — CBOE Volatility Index
+  ^TNX   — 10-year Treasury yield
+  ^TYX   — 30-year Treasury yield
+  ^FVX   — 5-year Treasury yield
+  ^IRX   — 13-week T-bill yield
+  ZQ=F   — 30-day Fed Funds Futures (front month)
+  ^GSPC  — S&P 500 index level
+
+Data is stored under data/indices/<SYMBOL>.parquet using the same schema
+and atomic-write pattern as the equity OHLCV pipeline.
+
+Usage
+-----
+    market-data-fetch-indices               # update all (or bootstrap if new)
+    market-data-fetch-indices --history 20  # pull 20 years of history
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from datetime import date
+from pathlib import Path
+
+from market_data.fetch import (
+    DEFAULT_HISTORY_YEARS,
+    fetch_history,
+    fetch_incremental,
+    load_ticker_data,
+    save_ticker_data,
+)
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+INDEX_SYMBOLS: list[str] = [
+    "^VIX",   # CBOE Volatility Index
+    "^TNX",   # 10-year Treasury yield
+    "^TYX",   # 30-year Treasury yield
+    "^FVX",   # 5-year Treasury yield
+    "^IRX",   # 13-week T-bill yield
+    "ZQ=F",   # 30-day Fed Funds Futures (front month)
+    "^GSPC",  # S&P 500 index level
+]
+
+INDICES_DIR = Path("data/indices")
+SLEEP_BETWEEN_CALLS = 3  # seconds
+
+
+# ---------------------------------------------------------------------------
+# Core logic
+# ---------------------------------------------------------------------------
+
+def update_symbol(symbol: str, history_years: int) -> int:
+    """
+    Bootstrap or incrementally update a single index/rate symbol.
+
+    If no local file exists yet, pulls `history_years` of history.
+    Otherwise pulls data since the last stored date.
+
+    Returns the number of new rows added.
+    """
+    existing = load_ticker_data(symbol, INDICES_DIR)
+
+    if existing is None:
+        df = fetch_history(symbol, years=history_years)
+        action = f"bootstrap ({history_years}y)"
+    else:
+        last_date = existing["date"].max()
+        df = fetch_incremental(symbol, since=last_date)
+        action = f"incremental since {last_date}"
+
+    if df.empty:
+        print(f"  {symbol:<8}  no data  ({action})")
+        return 0
+
+    added = save_ticker_data(symbol, df, INDICES_DIR)
+    print(f"  {symbol:<8}  +{added} rows  ({action})")
+    return added
+
+
+def run(symbols: list[str] | None = None, history_years: int = DEFAULT_HISTORY_YEARS) -> None:
+    """
+    Update all index/rate symbols (or a custom subset).
+    """
+    targets = symbols or INDEX_SYMBOLS
+    today = date.today()
+
+    print(f"\nmarket_data indices  —  {today}")
+    print(f"  Symbols: {', '.join(targets)}")
+    print(f"{'='*50}")
+
+    total_added = 0
+    for i, symbol in enumerate(targets):
+        try:
+            added = update_symbol(symbol, history_years)
+            total_added += added
+        except Exception as exc:
+            print(f"  {symbol:<8}  ERROR: {exc}")
+
+        if i < len(targets) - 1:
+            time.sleep(SLEEP_BETWEEN_CALLS)
+
+    print(f"{'='*50}")
+    print(f"Done.  {total_added} new rows across {len(targets)} symbols.\n")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Fetch/update market index and rate data (VIX, Treasury yields, etc.)."
+    )
+    parser.add_argument(
+        "--history",
+        type=int,
+        default=DEFAULT_HISTORY_YEARS,
+        metavar="YEARS",
+        help=f"Years of history to pull on first bootstrap (default: {DEFAULT_HISTORY_YEARS}).",
+    )
+    parser.add_argument(
+        "--symbols",
+        nargs="+",
+        metavar="SYMBOL",
+        help="Override the default symbol list (e.g. --symbols ^VIX ^TNX).",
+    )
+    args = parser.parse_args()
+
+    run(symbols=args.symbols, history_years=args.history)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/market_data/fetch_macro.py
+++ b/src/market_data/fetch_macro.py
@@ -1,0 +1,285 @@
+"""
+fetch_macro.py
+--------------
+Collect macroeconomic time series from the FRED API (Federal Reserve Bank
+of St. Louis).
+
+Series collected by default
+----------------------------
+Daily
+  DFF       Effective Federal Funds Rate
+  T10Y2Y    10-year minus 2-year Treasury spread
+
+Monthly
+  CPIAUCSL  CPI — All Urban Consumers (headline)
+  CPILFESL  Core CPI (ex food & energy)
+  PCEPI     PCE Price Index
+  PCEPILFE  Core PCE
+  UNRATE    Unemployment Rate
+  PAYEMS    Nonfarm Payrolls (thousands of jobs)
+
+Quarterly
+  GDPC1     Real GDP (chained 2017 dollars)
+  GDP       Nominal GDP
+
+Data is stored under data/macro/<SERIES_ID>.parquet.
+Schema: date (date), series_id (str), value (float).
+
+Requires
+--------
+  FRED_API_KEY environment variable (or .env file at project root).
+
+Usage
+-----
+    market-data-fetch-macro                        # update all default series
+    market-data-fetch-macro --series DFF T10Y2Y    # update specific series
+    market-data-fetch-macro --start 1990-01-01     # custom bootstrap start
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from datetime import date, timedelta
+from pathlib import Path
+
+import pandas as pd
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+MACRO_DIR = Path("data/macro")
+
+# Default bootstrap start date — FRED has data going back decades for most series
+DEFAULT_START = "1990-01-01"
+
+# Series to collect by default, grouped by frequency (for documentation clarity)
+DEFAULT_SERIES: list[str] = [
+    # Daily
+    "DFF",       # Effective Federal Funds Rate
+    "T10Y2Y",    # 10yr minus 2yr Treasury yield spread
+    # Monthly
+    "CPIAUCSL",  # CPI headline
+    "CPILFESL",  # Core CPI
+    "PCEPI",     # PCE Price Index
+    "PCEPILFE",  # Core PCE
+    "UNRATE",    # Unemployment Rate
+    "PAYEMS",    # Nonfarm Payrolls
+    # Quarterly
+    "GDPC1",     # Real GDP
+    "GDP",       # Nominal GDP
+]
+
+
+# ---------------------------------------------------------------------------
+# API key loading
+# ---------------------------------------------------------------------------
+
+def _load_api_key() -> str:
+    """
+    Load the FRED API key from the environment (or .env file).
+
+    Raises RuntimeError with a clear message if the key is missing so the
+    user knows exactly what to fix.
+    """
+    # Attempt to load .env from the current working directory
+    try:
+        from dotenv import load_dotenv  # type: ignore[import]
+        load_dotenv()
+    except ImportError:
+        pass  # python-dotenv not installed; rely on the real environment
+
+    key = os.environ.get("FRED_API_KEY", "").strip()
+    if not key:
+        raise RuntimeError(
+            "FRED_API_KEY is not set. Add it to your .env file:\n"
+            "  FRED_API_KEY=your_key_here\n"
+            "Get a free key at https://fred.stlouisfed.org/"
+        )
+    return key
+
+
+# ---------------------------------------------------------------------------
+# Storage helpers
+# ---------------------------------------------------------------------------
+
+def _series_path(series_id: str, macro_dir: Path) -> Path:
+    return macro_dir / f"{series_id}.parquet"
+
+
+def load_macro_series(series_id: str, macro_dir: Path) -> pd.DataFrame | None:
+    """Load an existing macro Parquet, or return None if it doesn't exist."""
+    path = _series_path(series_id, macro_dir)
+    if not path.exists():
+        return None
+    return pd.read_parquet(path)
+
+
+def save_macro_series(series_id: str, new_df: pd.DataFrame, macro_dir: Path) -> int:
+    """
+    Merge new_df into the existing per-series Parquet file.
+
+    Deduplicates on (date, series_id), sorts by date, and writes atomically.
+    Returns the number of net-new rows added.
+    """
+    if new_df.empty:
+        return 0
+
+    macro_dir.mkdir(parents=True, exist_ok=True)
+    path = _series_path(series_id, macro_dir)
+
+    if path.exists():
+        existing = pd.read_parquet(path)
+        combined = pd.concat([existing, new_df], ignore_index=True)
+        before = len(existing)
+    else:
+        combined = new_df.copy()
+        before = 0
+
+    combined["date"] = pd.to_datetime(combined["date"]).dt.date
+    combined = (
+        combined
+        .drop_duplicates(subset=["date", "series_id"])
+        .sort_values("date")
+        .reset_index(drop=True)
+    )
+
+    tmp_path = path.with_suffix(".tmp.parquet")
+    combined.to_parquet(tmp_path, index=False)
+    tmp_path.replace(path)
+
+    return len(combined) - before
+
+
+# ---------------------------------------------------------------------------
+# Fetch
+# ---------------------------------------------------------------------------
+
+def fetch_series(
+    series_id: str,
+    start: str,
+    api_key: str,
+) -> pd.DataFrame:
+    """
+    Pull a FRED series from `start` to today.
+
+    Returns a DataFrame with columns: date (date), series_id (str), value (float).
+    Returns an empty DataFrame if no data is available.
+    """
+    try:
+        import fredapi  # type: ignore[import]
+    except ImportError as exc:
+        raise ImportError(
+            "fredapi is not installed. Run: pip install fredapi"
+        ) from exc
+
+    fred = fredapi.Fred(api_key=api_key)
+    raw = fred.get_series(series_id, observation_start=start)
+
+    if raw is None or raw.empty:
+        return pd.DataFrame(columns=["date", "series_id", "value"])
+
+    df = raw.reset_index()
+    df.columns = ["date", "value"]
+    df["date"] = pd.to_datetime(df["date"]).dt.date
+    df["series_id"] = series_id
+    df = df[["date", "series_id", "value"]].dropna(subset=["value"])
+    df["value"] = df["value"].astype(float)
+
+    return df.reset_index(drop=True)
+
+
+# ---------------------------------------------------------------------------
+# Core run logic
+# ---------------------------------------------------------------------------
+
+def update_series(series_id: str, api_key: str, start: str, macro_dir: Path) -> int:
+    """
+    Bootstrap or incrementally update a single FRED series.
+
+    On first run: pulls from `start` to today.
+    On subsequent runs: pulls from (last stored date - 7 days) to today.
+    The 7-day lookback ensures we don't miss delayed revisions.
+
+    Returns the number of new rows added.
+    """
+    existing = load_macro_series(series_id, macro_dir)
+
+    if existing is None:
+        fetch_start = start
+        action = f"bootstrap from {start}"
+    else:
+        last_date = existing["date"].max()
+        # Look back 7 days to catch revisions / late-released data points
+        lookback = last_date - timedelta(days=7)
+        fetch_start = str(lookback)
+        action = f"incremental since {lookback}"
+
+    df = fetch_series(series_id, start=fetch_start, api_key=api_key)
+
+    if df.empty:
+        print(f"  {series_id:<12}  no data  ({action})")
+        return 0
+
+    added = save_macro_series(series_id, df, macro_dir)
+    print(f"  {series_id:<12}  +{added} rows  ({action})")
+    return added
+
+
+def run(
+    series_ids: list[str] | None = None,
+    start: str = DEFAULT_START,
+    macro_dir: Path = MACRO_DIR,
+) -> None:
+    """
+    Update all macro series (or a custom subset).
+    """
+    targets = series_ids or DEFAULT_SERIES
+    today = date.today()
+
+    api_key = _load_api_key()
+
+    print(f"\nmarket_data macro  —  {today}")
+    print(f"  Series  : {', '.join(targets)}")
+    print(f"{'='*55}")
+
+    total_added = 0
+    for series_id in targets:
+        try:
+            added = update_series(series_id, api_key=api_key, start=start, macro_dir=macro_dir)
+            total_added += added
+        except Exception as exc:
+            print(f"  {series_id:<12}  ERROR: {exc}")
+
+    print(f"{'='*55}")
+    print(f"Done.  {total_added} new rows across {len(targets)} series.\n")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Fetch/update macroeconomic series from FRED (CPI, GDP, Treasury, etc.)."
+    )
+    parser.add_argument(
+        "--series",
+        nargs="+",
+        metavar="SERIES_ID",
+        help="Override the default series list (e.g. --series DFF CPIAUCSL).",
+    )
+    parser.add_argument(
+        "--start",
+        default=DEFAULT_START,
+        metavar="YYYY-MM-DD",
+        help=f"Bootstrap start date (default: {DEFAULT_START}).",
+    )
+    args = parser.parse_args()
+
+    run(series_ids=args.series, start=args.start)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/market_data/fetch_options.py
+++ b/src/market_data/fetch_options.py
@@ -1,0 +1,360 @@
+"""
+fetch_options.py
+----------------
+Collect daily option chain snapshots for S&P 500 tickers via yfinance.
+
+For each ticker the nearest `max_expiries` expiration dates are fetched and
+all strikes (calls + puts) are stored as a single row-per-contract snapshot.
+
+Data source note
+----------------
+yfinance option chains are an unofficial Yahoo Finance scraper.  They are
+suitable for research and macro forecasting but should not be used for
+production order routing.  Greek values (delta, gamma, theta, vega) are NOT
+provided by yfinance; implied volatility is available but carries the same
+reliability caveat.
+
+Fields per contract
+-------------------
+  snapshot_date   date the snapshot was taken
+  symbol          underlying ticker
+  expiry          option expiration date
+  strike          strike price
+  option_type     "call" or "put"
+  last_price      last traded price
+  bid             bid price
+  ask             ask price
+  volume          contracts traded today
+  open_interest   total open contracts
+  implied_vol     implied volatility (annualised, as a decimal)
+  in_the_money    True if the contract is currently ITM
+
+Batching
+--------
+500 SP500 tickers at ~5 seconds/call is ~40 minutes.  This module supports
+batching: each run processes the next `batch_size` SP500 tickers that have
+not yet been snapshotted in the current cycle.  When all SP500 tickers have
+been covered the cycle resets automatically.
+
+Cycle state is tracked in state.json under the key "options_cycle".
+
+Usage
+-----
+    market-data-fetch-options                          # next batch (default 50)
+    market-data-fetch-options --batch-size 25          # smaller batch
+    market-data-fetch-options --symbols AAPL MSFT      # specific symbols (no state)
+    market-data-fetch-options --max-expiries 2         # fewer expiry dates
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+import yfinance as yf
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+OPTIONS_DIR = Path("data/options")
+STATE_FILE = Path("state.json")
+TICKERS_FILE = Path("tickers.csv")
+
+DEFAULT_BATCH_SIZE = 50
+DEFAULT_MAX_EXPIRIES = 4
+SLEEP_BETWEEN_CALLS = 5  # seconds
+
+OPTIONS_COLS = [
+    "snapshot_date",
+    "symbol",
+    "expiry",
+    "strike",
+    "option_type",
+    "last_price",
+    "bid",
+    "ask",
+    "volume",
+    "open_interest",
+    "implied_vol",
+    "in_the_money",
+]
+
+
+# ---------------------------------------------------------------------------
+# Ticker helpers
+# ---------------------------------------------------------------------------
+
+def get_sp500_symbols(onboarded: set[str]) -> list[str]:
+    """
+    Return SP500 symbols from tickers.csv that are also in the onboarded set,
+    sorted by market value descending (largest cap first).
+
+    Falls back to all onboarded tickers if tickers.csv is missing or has no
+    index column.
+    """
+    if not TICKERS_FILE.exists():
+        return sorted(onboarded)
+
+    df = pd.read_csv(TICKERS_FILE)
+
+    if "index" in df.columns:
+        sp500 = df[df["index"].str.contains("SP500", na=False)]
+    else:
+        sp500 = df  # fallback: treat everything as eligible
+
+    symbols = sp500["symbol"].dropna().astype(str).tolist()
+    # Restrict to onboarded (we need OHLCV data before options is useful)
+    return [s for s in symbols if s in onboarded]
+
+
+# ---------------------------------------------------------------------------
+# Fetch
+# ---------------------------------------------------------------------------
+
+def fetch_option_chain(symbol: str, max_expiries: int) -> pd.DataFrame:
+    """
+    Fetch the nearest `max_expiries` option chains for `symbol`.
+
+    Returns a DataFrame with OPTIONS_COLS schema, or an empty DataFrame if
+    no data is available.
+    """
+    ticker = yf.Ticker(symbol)
+
+    try:
+        expiry_dates = ticker.options  # tuple of expiry date strings
+    except Exception:
+        return pd.DataFrame(columns=OPTIONS_COLS)
+
+    if not expiry_dates:
+        return pd.DataFrame(columns=OPTIONS_COLS)
+
+    today = date.today()
+    selected = expiry_dates[:max_expiries]
+    frames: list[pd.DataFrame] = []
+
+    for expiry_str in selected:
+        try:
+            chain = ticker.option_chain(expiry_str)
+        except Exception:
+            continue
+
+        for side, df_raw in (("call", chain.calls), ("put", chain.puts)):
+            if df_raw.empty:
+                continue
+
+            df = pd.DataFrame()
+            df["snapshot_date"] = today
+            df["symbol"] = symbol
+            df["expiry"] = pd.to_datetime(expiry_str).date()
+            df["strike"] = pd.to_numeric(df_raw.get("strike"), errors="coerce")
+            df["option_type"] = side
+            df["last_price"] = pd.to_numeric(df_raw.get("lastPrice"), errors="coerce")
+            df["bid"] = pd.to_numeric(df_raw.get("bid"), errors="coerce")
+            df["ask"] = pd.to_numeric(df_raw.get("ask"), errors="coerce")
+            df["volume"] = pd.to_numeric(df_raw.get("volume"), errors="coerce")
+            df["open_interest"] = pd.to_numeric(df_raw.get("openInterest"), errors="coerce")
+            df["implied_vol"] = pd.to_numeric(df_raw.get("impliedVolatility"), errors="coerce")
+            df["in_the_money"] = df_raw.get("inTheMoney", pd.Series(dtype=bool))
+
+            frames.append(df[OPTIONS_COLS])
+
+    if not frames:
+        return pd.DataFrame(columns=OPTIONS_COLS)
+
+    return pd.concat(frames, ignore_index=True)
+
+
+# ---------------------------------------------------------------------------
+# Storage
+# ---------------------------------------------------------------------------
+
+def _options_path(symbol: str, options_dir: Path) -> Path:
+    return options_dir / f"{symbol}.parquet"
+
+
+def save_options_snapshot(
+    symbol: str,
+    new_df: pd.DataFrame,
+    options_dir: Path,
+) -> int:
+    """
+    Append new_df to the per-ticker options Parquet.
+
+    Deduplicates on (snapshot_date, symbol, expiry, strike, option_type) so
+    re-running on the same day is safe.  Writes atomically.
+
+    Returns the number of net-new rows added.
+    """
+    if new_df.empty:
+        return 0
+
+    options_dir.mkdir(parents=True, exist_ok=True)
+    path = _options_path(symbol, options_dir)
+
+    if path.exists():
+        existing = pd.read_parquet(path)
+        combined = pd.concat([existing, new_df], ignore_index=True)
+        before = len(existing)
+    else:
+        combined = new_df.copy()
+        before = 0
+
+    dedup_keys = ["snapshot_date", "symbol", "expiry", "strike", "option_type"]
+    combined["snapshot_date"] = pd.to_datetime(combined["snapshot_date"]).dt.date
+    combined["expiry"] = pd.to_datetime(combined["expiry"]).dt.date
+    combined = (
+        combined
+        .drop_duplicates(subset=dedup_keys)
+        .sort_values(["snapshot_date", "expiry", "strike", "option_type"])
+        .reset_index(drop=True)
+    )
+
+    tmp_path = path.with_suffix(".tmp.parquet")
+    combined.to_parquet(tmp_path, index=False)
+    tmp_path.replace(path)
+
+    return len(combined) - before
+
+
+# ---------------------------------------------------------------------------
+# Core run logic
+# ---------------------------------------------------------------------------
+
+def run(
+    symbols: list[str],
+    options_dir: Path = OPTIONS_DIR,
+    max_expiries: int = DEFAULT_MAX_EXPIRIES,
+) -> None:
+    """
+    Fetch and store option chain snapshots for each symbol in `symbols`.
+    """
+    today = date.today()
+    total = len(symbols)
+
+    print(f"\nmarket_data options  —  {today}")
+    print(f"  Tickers    : {total}")
+    print(f"  Max expiries: {max_expiries}")
+    print(f"{'='*55}")
+
+    saved_rows = 0
+    skipped = 0
+    failed = 0
+
+    for i, symbol in enumerate(symbols, 1):
+        prefix = f"  [{i:>3}/{total}] {symbol:<8}"
+        try:
+            df = fetch_option_chain(symbol, max_expiries=max_expiries)
+            if df.empty:
+                print(f"{prefix}  no data")
+                skipped += 1
+            else:
+                added = save_options_snapshot(symbol, df, options_dir)
+                expiry_count = df["expiry"].nunique()
+                print(f"{prefix}  +{added} rows  ({expiry_count} expiries)")
+                saved_rows += added
+        except Exception as exc:
+            print(f"{prefix}  ERROR: {exc}")
+            failed += 1
+
+        if i < total:
+            time.sleep(SLEEP_BETWEEN_CALLS)
+
+    print(f"{'='*55}")
+    print(f"Done.  Rows saved: {saved_rows}  |  Skipped: {skipped}  |  Failed: {failed}\n")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Fetch daily option chain snapshots (IV, bid/ask, OI) for SP500 tickers "
+            "via yfinance.  Processes tickers in batches across days; cycle state is "
+            "tracked in state.json."
+        )
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=DEFAULT_BATCH_SIZE,
+        metavar="N",
+        help=f"Tickers to process per run (default: {DEFAULT_BATCH_SIZE}).",
+    )
+    parser.add_argument(
+        "--max-expiries",
+        type=int,
+        default=DEFAULT_MAX_EXPIRIES,
+        metavar="N",
+        help=f"Expiration dates to fetch per ticker (default: {DEFAULT_MAX_EXPIRIES}).",
+    )
+    parser.add_argument(
+        "--symbols",
+        nargs="+",
+        metavar="SYMBOL",
+        help="Override batch logic and fetch specific symbols only.",
+    )
+    args = parser.parse_args()
+
+    if args.symbols:
+        # Direct symbol override — bypass state/batching entirely
+        run(symbols=args.symbols, max_expiries=args.max_expiries)
+        return
+
+    # --- Load state ---
+    if not STATE_FILE.exists():
+        print("No state.json found. Run market-data-run first to onboard tickers.")
+        return
+
+    state = json.loads(STATE_FILE.read_text())
+    onboarded: set[str] = set(state.get("onboarded", []))
+
+    if not onboarded:
+        print("No onboarded tickers in state.json. Run market-data-run first.")
+        return
+
+    sp500 = get_sp500_symbols(onboarded)
+    if not sp500:
+        print("No SP500 tickers found in onboarded set.")
+        return
+
+    # --- Determine batch from cycle state ---
+    cycle_done: list[str] = state.get("options_cycle", [])
+    cycle_done_set = set(cycle_done)
+
+    pending = [s for s in sp500 if s not in cycle_done_set]
+
+    if not pending:
+        # Full cycle complete — reset and start over
+        print(f"Options cycle complete ({len(sp500)} tickers covered). Resetting cycle.")
+        cycle_done = []
+        cycle_done_set = set()
+        pending = list(sp500)
+
+    batch = pending[:args.batch_size]
+    remaining_after = len(pending) - len(batch)
+
+    print(f"\nOptions cycle progress: {len(cycle_done_set)}/{len(sp500)} done  "
+          f"|  {len(pending)} pending  |  processing {len(batch)} this run")
+
+    run(symbols=batch, max_expiries=args.max_expiries)
+
+    # --- Persist updated cycle state ---
+    state["options_cycle"] = sorted(cycle_done_set | set(batch))
+    STATE_FILE.write_text(json.dumps(state, indent=2, default=str))
+
+    if remaining_after == 0:
+        print(f"Options cycle complete — all {len(sp500)} SP500 tickers covered.")
+    else:
+        days_remaining = (remaining_after + args.batch_size - 1) // args.batch_size
+        print(f"~{days_remaining} more run(s) to complete this cycle.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/market_data/orchestrator.py
+++ b/src/market_data/orchestrator.py
@@ -3,23 +3,41 @@ orchestrator.py
 ---------------
 Daily runner for the market_data pipeline.
 
-Each run does two things, in order:
+Each run executes in order:
 
-  1. ONBOARD  — pick the next `--batch-size` tickers from tickers.csv that
-                haven't been fetched yet, and pull their full 10-year history.
+  1. ONBOARD       — pick the next `--batch-size` tickers from tickers.csv that
+                     haven't been fetched yet, and pull their full 10-year history.
 
-  2. UPDATE   — for every already-onboarded ticker, pull any new trading days
-                since the last run and append them to their Parquet file.
+  2. UPDATE        — for every already-onboarded ticker, pull any new trading days
+                     since the last run and append them to their Parquet file.
+
+  3. FUNDAMENTALS  — (optional, monthly) snapshot market cap, analyst estimates,
+                     and valuation ratios for all onboarded tickers via yfinance.
+                     Auto-skipped if last run was <30 days ago.
+
+  4. OPTIONS       — (optional, daily) fetch option chain snapshots (IV, bid/ask,
+                     open interest) for the next batch of SP500 tickers. Processes
+                     50 tickers/run across a ~10-day rolling cycle; cycle state is
+                     tracked in state.json under "options_cycle".
+
+  5. INDICES       — (optional, daily) update VIX, Treasury yields, Fed Funds
+                     futures, and S&P 500 index level.
+
+  6. MACRO         — (optional, daily) update FRED macro series (CPI, GDP,
+                     Fed Funds rate, Treasury spread, unemployment, etc.).
+
+  7. MERGE         — (optional) rebuild data/merged.parquet from all per-ticker
+                     OHLCV files.
 
 Progress is persisted in state.json so runs are safe to interrupt and resume.
 
 Usage
 -----
-    python orchestrator.py                        # default batch size (50)
-    python orchestrator.py --batch-size 25        # onboard fewer per day
-    python orchestrator.py --batch-size 0         # updates only, no new tickers
-    python orchestrator.py --no-update            # onboard only, skip updates
-    python orchestrator.py --merge                # run merge.py when done
+    market-data-run                                          # OHLCV only
+    market-data-run --batch-size 25                         # onboard fewer per day
+    market-data-run --batch-size 0                          # updates only, no new tickers
+    market-data-run --no-update                             # onboard only, skip updates
+    market-data-run --indices --macro --fundamentals --options --merge # full daily run (recommended)
 """
 
 from __future__ import annotations
@@ -45,6 +63,9 @@ DATA_DIR = Path("data")
 DEFAULT_BATCH_SIZE = 50
 SLEEP_BETWEEN_CALLS = 5  # seconds; be polite to the yfinance endpoint
 TICKER_REFRESH_DAYS = 90
+FUNDAMENTALS_REFRESH_DAYS = 30
+DEFAULT_OPTIONS_BATCH_SIZE = 50
+DEFAULT_MAX_EXPIRIES = 4
 
 
 # ---------------------------------------------------------------------------
@@ -58,8 +79,16 @@ def load_state() -> dict:
             "onboarded": raw.get("onboarded", []),
             "last_run": raw.get("last_run"),
             "last_ticker_refresh": raw.get("last_ticker_refresh"),
+            "last_fundamentals_run": raw.get("last_fundamentals_run"),
+            "options_cycle": raw.get("options_cycle", []),
         }
-    return {"onboarded": [], "last_run": None, "last_ticker_refresh": None}
+    return {
+        "onboarded": [],
+        "last_run": None,
+        "last_ticker_refresh": None,
+        "last_fundamentals_run": None,
+        "options_cycle": [],
+    }
 
 
 def save_state(state: dict) -> None:
@@ -98,6 +127,88 @@ def maybe_refresh_tickers(
     except Exception as exc:
         print(f"  WARNING: Ticker refresh failed: {exc}. Continuing with existing list.")
         return False
+
+
+# ---------------------------------------------------------------------------
+# Fundamentals refresh
+# ---------------------------------------------------------------------------
+
+def maybe_run_fundamentals(
+    state: dict,
+    onboarded: set[str],
+    today: date,
+) -> bool:
+    """
+    Run a fundamentals snapshot if last_fundamentals_run is absent or >30 days ago.
+    Returns True if fundamentals were fetched this run.
+
+    Failures are non-fatal and logged as warnings.
+    """
+    last_raw = state.get("last_fundamentals_run")
+    if last_raw:
+        days_since = (today - date.fromisoformat(last_raw)).days
+        if days_since < FUNDAMENTALS_REFRESH_DAYS:
+            print(f"  Fundamentals are fresh ({days_since}d old, threshold {FUNDAMENTALS_REFRESH_DAYS}d)")
+            return False
+
+    symbols = sorted(onboarded)
+    print(f"\nFetching fundamentals for {len(symbols)} tickers "
+          f"(last run: {last_raw or 'never'})...")
+    try:
+        from market_data import fetch_fundamentals  # noqa: PLC0415
+        fetch_fundamentals.run(symbols=symbols)
+        return True
+    except Exception as exc:
+        print(f"  WARNING: Fundamentals fetch failed: {exc}.")
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Options batch step
+# ---------------------------------------------------------------------------
+
+def step_options(
+    state: dict,
+    onboarded: set[str],
+    batch_size: int,
+    max_expiries: int,
+) -> set[str]:
+    """
+    Process the next `batch_size` SP500 tickers in the options cycle.
+
+    Returns the updated set of tickers covered in the current cycle so the
+    caller can persist it to state.json.
+    """
+    from market_data import fetch_options  # noqa: PLC0415
+
+    sp500 = fetch_options.get_sp500_symbols(onboarded)
+    if not sp500:
+        print("  OPTIONS  no SP500 tickers in onboarded set — skipping.")
+        return set(state.get("options_cycle", []))
+
+    cycle_done: set[str] = set(state.get("options_cycle", []))
+    pending = [s for s in sp500 if s not in cycle_done]
+
+    if not pending:
+        print(f"  OPTIONS  cycle complete ({len(sp500)} tickers). Resetting cycle.")
+        cycle_done = set()
+        pending = list(sp500)
+
+    batch = pending[:batch_size]
+    remaining_after = len(pending) - len(batch)
+
+    print(f"\n{'='*60}")
+    print(f"OPTIONS  {len(batch)} tickers  "
+          f"(cycle: {len(cycle_done)}/{len(sp500)} done, {remaining_after} remaining after this batch)")
+    print(f"{'='*60}")
+
+    fetch_options.run(symbols=batch, max_expiries=max_expiries)
+
+    updated_cycle = cycle_done | set(batch)
+    if remaining_after == 0:
+        print(f"  Options cycle complete — all {len(sp500)} SP500 tickers covered.")
+        return set()  # reset for next cycle
+    return updated_cycle
 
 
 # ---------------------------------------------------------------------------
@@ -209,7 +320,7 @@ def step_update(
 # Main
 # ---------------------------------------------------------------------------
 
-def run(batch_size: int, skip_update: bool, run_merge: bool) -> None:
+def run(batch_size: int, skip_update: bool, run_merge: bool, run_indices: bool = False, run_macro: bool = False, run_fundamentals: bool = False, run_options: bool = False, options_batch_size: int = 50) -> None:
     today = date.today()
 
     state = load_state()
@@ -244,14 +355,40 @@ def run(batch_size: int, skip_update: bool, run_merge: bool) -> None:
     elif not skip_update and not last_run:
         print("\nUPDATE   skipped — no previous run date in state.json")
 
-    # --- 3. Persist state ---
+    # --- 3. Optional fundamentals snapshot (auto-throttled to monthly) ---
+    fundamentals_ran = False
+    if run_fundamentals:
+        fundamentals_ran = maybe_run_fundamentals(state, onboarded, today)
+
+    # --- 4. Optional options chain batch ---
+    updated_options_cycle: set[str] | None = None
+    if run_options:
+        updated_options_cycle = step_options(
+            state, onboarded, batch_size=options_batch_size, max_expiries=DEFAULT_MAX_EXPIRIES
+        )
+
+    # --- 5. Optional indices update ---
+    if run_indices:
+        from market_data import fetch_indices  # noqa: PLC0415
+        fetch_indices.run()
+
+    # --- 6. Optional macro update ---
+    if run_macro:
+        from market_data import fetch_macro  # noqa: PLC0415
+        fetch_macro.run()
+
+    # --- 7. Persist state ---
     state["onboarded"] = sorted(onboarded)
     state["last_run"] = str(today)
     if refreshed:
         state["last_ticker_refresh"] = str(today)
+    if fundamentals_ran:
+        state["last_fundamentals_run"] = str(today)
+    if updated_options_cycle is not None:
+        state["options_cycle"] = sorted(updated_options_cycle)
     save_state(state)
 
-    # --- 4. Summary ---
+    # --- 7. Summary ---
     remaining = len([t for t in all_tickers if t not in onboarded])
     print(f"\n{'='*60}")
     print(f"Done.  Onboarded: {len(onboarded)}/{len(all_tickers)}  |  "
@@ -261,7 +398,7 @@ def run(batch_size: int, skip_update: bool, run_merge: bool) -> None:
         print(f"At {batch_size} tickers/day  →  ~{eta} more day(s) to full coverage")
     print(f"{'='*60}\n")
 
-    # --- 5. Optional merge ---
+    # --- 8. Optional merge ---
     if run_merge:
         from market_data import merge  # noqa: PLC0415
         merge.run(DATA_DIR)
@@ -288,12 +425,50 @@ def main() -> None:
         action="store_true",
         help="Run merge.py after the pipeline completes.",
     )
+    parser.add_argument(
+        "--indices",
+        action="store_true",
+        help="Also update index/rate symbols (VIX, Treasury yields, Fed Funds futures).",
+    )
+    parser.add_argument(
+        "--macro",
+        action="store_true",
+        help="Also update FRED macro series (CPI, GDP, Fed Funds rate, etc.).",
+    )
+    parser.add_argument(
+        "--fundamentals",
+        action="store_true",
+        help=(
+            "Also snapshot per-ticker fundamentals (market cap, analyst estimates, etc.). "
+            f"Auto-skipped if last run was <{FUNDAMENTALS_REFRESH_DAYS} days ago."
+        ),
+    )
+    parser.add_argument(
+        "--options",
+        action="store_true",
+        help=(
+            "Also run the options chain batch (IV, bid/ask, OI) for SP500 tickers. "
+            f"Processes the next --options-batch-size tickers in the cycle (default: {DEFAULT_OPTIONS_BATCH_SIZE})."
+        ),
+    )
+    parser.add_argument(
+        "--options-batch-size",
+        type=int,
+        default=DEFAULT_OPTIONS_BATCH_SIZE,
+        metavar="N",
+        help=f"SP500 tickers to process per options run (default: {DEFAULT_OPTIONS_BATCH_SIZE}).",
+    )
     args = parser.parse_args()
 
     run(
         batch_size=args.batch_size,
         skip_update=args.no_update,
         run_merge=args.merge,
+        run_indices=args.indices,
+        run_macro=args.macro,
+        run_fundamentals=args.fundamentals,
+        run_options=args.options,
+        options_batch_size=args.options_batch_size,
     )
 
 


### PR DESCRIPTION
## Summary

- **Phase 1 — Market indices & rates** (`fetch_indices.py`): daily VIX, Treasury yields (5/10/30yr, T-bill), 30-day Fed Funds futures, and S&P 500 level via yfinance → `data/indices/`
- **Phase 2 — FRED macro data** (`fetch_macro.py`): CPI, core CPI, PCE, core PCE, real/nominal GDP, effective Fed Funds rate, 10yr–2yr Treasury spread, unemployment, nonfarm payrolls → `data/macro/`; bootstraps from 1990, incremental updates with 7-day revision lookback; reads `FRED_API_KEY` from `.env`
- **Phase 3 — Per-ticker fundamentals** (`fetch_fundamentals.py`): monthly snapshots of market cap, EV, P/E, P/B, EPS, revenue, margins, and analyst price targets/recommendations → `data/fundamentals/`; auto-throttled to 30-day cadence via `state.json`
- **Phase 4 — Options chains / IV** (`fetch_options.py`): daily SP500 option chain snapshots (implied vol, bid/ask, open interest) for nearest 4 expiries; batched 50 tickers/day across a ~10-day rolling cycle → `data/options/`; cycle state tracked in `state.json`

## Orchestrator changes

All new data types are opt-in flags on `market-data-run`:

```
market-data-run --indices --macro --fundamentals --options --merge
```

`run_and_sleep.bat` updated to use the full command above.

## New CLI commands

| Command | Description |
|---------|-------------|
| `market-data-fetch-indices` | Update index/rate symbols |
| `market-data-fetch-macro` | Update FRED macro series |
| `market-data-fetch-fundamentals` | Snapshot per-ticker fundamentals |
| `market-data-fetch-options` | Run next options chain batch |

## New dependencies

- `fredapi>=0.5` — FRED API client
- `python-dotenv>=1.0` — loads `.env` for `FRED_API_KEY`

## Setup required after merge

```bash
pip install -e .
# Add FRED_API_KEY to .env, then bootstrap:
market-data-fetch-indices
market-data-fetch-macro
market-data-fetch-fundamentals
```

## Test plan

- [ ] `pip install -e .` registers all 4 new CLI entry points
- [ ] `market-data-fetch-indices` bootstraps `data/indices/*.parquet` for all 7 symbols
- [ ] `market-data-fetch-macro` bootstraps `data/macro/*.parquet` for all 10 FRED series
- [ ] `market-data-fetch-fundamentals` snapshots `data/fundamentals/*.parquet` for onboarded tickers
- [ ] `market-data-fetch-options` processes first batch and writes `data/options/*.parquet`; `state.json` contains `options_cycle`
- [ ] Re-running on the same day produces 0 new rows (dedup working)
- [ ] `market-data-run --merge` still works with no regressions to OHLCV pipeline