### PR TITLE
Add sector and broad-market ETF data collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+### Added
+- `etf_config.py` — central registry of sector and broad-market ETFs tracked by the
+  pipeline. Defines two groups:
+  - `SECTOR_ETFS`: the 11 SPDR Select Sector ETFs (XLF, XLK, XLE, XLV, XLI, XLP,
+    XLY, XLU, XLB, XLRE, XLC)
+  - `BROAD_ETFS`: 8 broad-market / asset-class ETFs (SPY, QQQ, IWM, IVV, DIA, GLD,
+    TLT, HYG)
+  - `ALL_ETFS`: flat symbol list combining both groups
+
+### Changed
+- `fetch_tickers.py`: ETF rows are now injected into `tickers.csv` at ticker-refresh
+  time via `_inject_etf_rows()`. Sector ETFs receive `index = "SECTOR_ETF"`;
+  broad-market ETFs receive `index = "BROAD_ETF"`. `date_added` tracking works the
+  same as for index constituents.
+- `orchestrator.py`:
+  - ETFs are now priority-onboarded at the start of each run (outside the normal
+    `--batch-size` batch limit) so they are not queued behind ~1,500 stock tickers.
+  - Fundamentals snapshots now skip ETF symbols — yfinance `.info` fields for fund
+    wrappers don't map to the equity fundamentals schema.
+  - Options cycle now includes ETF symbols (via `fetch_options.get_etf_symbols()`)
+    ahead of SP500 constituents, ensuring ETFs are covered at the start of every cycle.
+- `fetch_options.py`:
+  - New `get_etf_symbols(onboarded)` function returns onboarded ETF symbols in
+    `etf_config` order (sector first, then broad).
+  - Standalone CLI (`market-data-fetch-options`) now includes ETFs in the cycle
+    alongside SP500 tickers.
+
+### Notes
+- ETFs collect OHLCV history and options chains; fundamentals are intentionally
+  skipped (not meaningful for fund wrappers).
+- ETF holdings (top-N holdings, sector weights) are deferred to Phase 2 — see
+  `backlog.md` for details.
+
 ---
 
 ## [0.2.4.2] — 2026-04-06

--- a/backlog.md
+++ b/backlog.md
@@ -23,6 +23,17 @@ Wishlist items — not needed for MVP. Revisit when the core pipeline is stable.
     trading day
   - Tag each ticker row with whether it was in the index on that date
 
+## ETF Data
+
+- **ETF holdings snapshots (Phase 2)**
+  SSGA publishes daily holdings CSVs for all SPDR ETFs; iShares does the same.
+  A `fetch_etf_holdings.py` module could snapshot each ETF's top-N holdings and
+  sector weights over time, enabling holdings-drift analysis and rebalancing
+  signals for backtests.
+  - Schema: `(as_of_date, etf_symbol, holding_symbol, weight, shares, market_value)`
+  - Storage: `data/etf_holdings/<SYMBOL>.parquet`
+  - Orchestrator step: `maybe_run_etf_holdings()` (daily cadence, like indices)
+
 ## Options & Implied Volatility
 
 - **Upgrade options source (post Phase 4)**

--- a/src/market_data/etf_config.py
+++ b/src/market_data/etf_config.py
@@ -1,0 +1,51 @@
+"""
+etf_config.py
+-------------
+Static configuration for sector and broad-market ETFs tracked by the pipeline.
+
+These symbols are injected into tickers.csv with index = "SECTOR_ETF" or
+"BROAD_ETF" at ticker-refresh time (see fetch_tickers.py) and are treated
+differently from index constituents:
+
+  - OHLCV history and incremental updates:  yes (same as stocks)
+  - Options chains:                          yes (liquid options markets)
+  - Fundamentals snapshots:                 no (not meaningful for fund wrappers)
+
+# TODO: Phase 2 — ETF holdings collection
+# SSGA publishes daily holdings CSVs for all SPDR ETFs (and iShares does the
+# same for their funds). A future fetch_etf_holdings.py module could snapshot
+# each ETF's top-N holdings and sector weights over time, enabling
+# holdings-drift analysis and rebalancing-signal features for backtests.
+# Schema would be: (as_of_date, etf_symbol, holding_symbol, weight, shares,
+# market_value), stored in data/etf_holdings/<SYMBOL>.parquet.
+"""
+
+# The 11 SPDR Select Sector ETFs — canonical sector decomposition of the S&P 500.
+SECTOR_ETFS: list[tuple[str, str]] = [
+    ("XLF",  "Financial Select Sector SPDR Fund"),
+    ("XLK",  "Technology Select Sector SPDR Fund"),
+    ("XLE",  "Energy Select Sector SPDR Fund"),
+    ("XLV",  "Health Care Select Sector SPDR Fund"),
+    ("XLI",  "Industrial Select Sector SPDR Fund"),
+    ("XLP",  "Consumer Staples Select Sector SPDR Fund"),
+    ("XLY",  "Consumer Discretionary Select Sector SPDR Fund"),
+    ("XLU",  "Utilities Select Sector SPDR Fund"),
+    ("XLB",  "Materials Select Sector SPDR Fund"),
+    ("XLRE", "Real Estate Select Sector SPDR Fund"),
+    ("XLC",  "Communication Services Select Sector SPDR Fund"),
+]
+
+# Broad-market and asset-class ETFs for macro/factor context.
+BROAD_ETFS: list[tuple[str, str]] = [
+    ("SPY", "SPDR S&P 500 ETF Trust"),
+    ("QQQ", "Invesco QQQ Trust (Nasdaq-100)"),
+    ("IWM", "iShares Russell 2000 ETF"),
+    ("IVV", "iShares Core S&P 500 ETF"),
+    ("DIA", "SPDR Dow Jones Industrial Average ETF Trust"),
+    ("GLD", "SPDR Gold Shares"),
+    ("TLT", "iShares 20+ Year Treasury Bond ETF"),
+    ("HYG", "iShares iBoxx $ High Yield Corporate Bond ETF"),
+]
+
+# All ETFs tracked by the pipeline (sector + broad), as a flat symbol list.
+ALL_ETFS: list[str] = [sym for sym, _ in SECTOR_ETFS + BROAD_ETFS]

--- a/src/market_data/etf_config.py
+++ b/src/market_data/etf_config.py
@@ -35,16 +35,60 @@ SECTOR_ETFS: list[tuple[str, str]] = [
     ("XLC",  "Communication Services Select Sector SPDR Fund"),
 ]
 
-# Broad-market and asset-class ETFs for macro/factor context.
+# Broad-market, factor, fixed-income, commodity, and international ETFs.
 BROAD_ETFS: list[tuple[str, str]] = [
-    ("SPY", "SPDR S&P 500 ETF Trust"),
-    ("QQQ", "Invesco QQQ Trust (Nasdaq-100)"),
-    ("IWM", "iShares Russell 2000 ETF"),
-    ("IVV", "iShares Core S&P 500 ETF"),
-    ("DIA", "SPDR Dow Jones Industrial Average ETF Trust"),
-    ("GLD", "SPDR Gold Shares"),
-    ("TLT", "iShares 20+ Year Treasury Bond ETF"),
-    ("HYG", "iShares iBoxx $ High Yield Corporate Bond ETF"),
+    # --- Broad Market ---
+    ("SPY",  "SPDR S&P 500 ETF Trust"),
+    ("VOO",  "Vanguard S&P 500 ETF"),
+    ("IVV",  "iShares Core S&P 500 ETF"),
+    ("QQQ",  "Invesco QQQ Trust (Nasdaq-100)"),
+    ("VTI",  "Vanguard Total Stock Market ETF"),
+    ("DIA",  "SPDR Dow Jones Industrial Average ETF Trust"),
+    ("MDY",  "SPDR S&P MidCap 400 ETF Trust"),
+    ("IJR",  "iShares Core S&P Small-Cap ETF"),
+    ("IWM",  "iShares Russell 2000 ETF"),
+    # --- Factors ---
+    ("MTUM", "iShares MSCI USA Momentum Factor ETF"),
+    ("QUAL", "iShares MSCI USA Quality Factor ETF"),
+    ("VLUE", "iShares MSCI USA Value Factor ETF"),
+    ("USMV", "iShares MSCI USA Min Vol Factor ETF"),
+    ("SIZE", "iShares MSCI USA Size Factor ETF"),
+    ("IWF",  "iShares Russell 1000 Growth ETF"),
+    ("IWD",  "iShares Russell 1000 Value ETF"),
+    ("IWO",  "iShares Russell 2000 Growth ETF"),
+    ("IWN",  "iShares Russell 2000 Value ETF"),
+    # --- Bonds ---
+    ("AGG",  "iShares Core US Aggregate Bond ETF"),
+    ("BND",  "Vanguard Total Bond Market ETF"),
+    ("LQD",  "iShares iBoxx $ Investment Grade Corporate Bond ETF"),
+    ("HYG",  "iShares iBoxx $ High Yield Corporate Bond ETF"),
+    ("JNK",  "SPDR Bloomberg High Yield Bond ETF"),
+    ("SHY",  "iShares 1-3 Year Treasury Bond ETF"),
+    ("IEF",  "iShares 7-10 Year Treasury Bond ETF"),
+    ("TLT",  "iShares 20+ Year Treasury Bond ETF"),
+    ("TIPS", "iShares TIPS Bond ETF"),
+    ("EMB",  "iShares JP Morgan USD Emerging Markets Bond ETF"),
+    ("MUB",  "iShares National Muni Bond ETF"),
+    # --- Commodities ---
+    ("GLD",  "SPDR Gold Shares"),
+    ("SLV",  "iShares Silver Trust"),
+    ("USO",  "United States Oil Fund"),
+    ("UNG",  "United States Natural Gas Fund"),
+    ("PDBC", "Invesco Optimum Yield Diversified Commodity Strategy ETF"),
+    ("CORN", "Teucrium Corn Fund"),
+    ("WEAT", "Teucrium Wheat Fund"),
+    ("DBA",  "Invesco DB Agriculture Fund"),
+    # --- International ---
+    ("EFA",  "iShares MSCI EAFE ETF (Developed Markets ex-US)"),
+    ("IEFA", "iShares Core MSCI EAFE ETF"),
+    ("EEM",  "iShares MSCI Emerging Markets ETF"),
+    ("IEMG", "iShares Core MSCI Emerging Markets ETF"),
+    ("VEA",  "Vanguard FTSE Developed Markets ETF"),
+    ("VWO",  "Vanguard FTSE Emerging Markets ETF"),
+    ("FXI",  "iShares China Large-Cap ETF"),
+    ("EWJ",  "iShares MSCI Japan ETF"),
+    ("EWZ",  "iShares MSCI Brazil ETF"),
+    ("EWG",  "iShares MSCI Germany ETF"),
 ]
 
 # All ETFs tracked by the pipeline (sector + broad), as a flat symbol list.

--- a/src/market_data/fetch_options.py
+++ b/src/market_data/fetch_options.py
@@ -1,7 +1,8 @@
 """
 fetch_options.py
 ----------------
-Collect daily option chain snapshots for S&P 500 tickers via yfinance.
+Collect daily option chain snapshots for S&P 500 tickers and sector/broad-market
+ETFs via yfinance.
 
 For each ticker the nearest `max_expiries` expiration dates are fetched and
 all strikes (calls + puts) are stored as a single row-per-contract snapshot.
@@ -31,10 +32,10 @@ Fields per contract
 
 Batching
 --------
-500 SP500 tickers at ~5 seconds/call is ~40 minutes.  This module supports
-batching: each run processes the next `batch_size` SP500 tickers that have
-not yet been snapshotted in the current cycle.  When all SP500 tickers have
-been covered the cycle resets automatically.
+ETFs (19) are always processed first in each cycle; the remaining ~500 SP500
+tickers follow in market-cap order.  Each run processes the next `batch_size`
+tickers not yet covered in the current cycle.  When all tickers have been
+covered the cycle resets automatically.
 
 Cycle state is tracked in state.json under the key "options_cycle".
 
@@ -110,6 +111,15 @@ def get_sp500_symbols(onboarded: set[str]) -> list[str]:
     symbols = sp500["symbol"].dropna().astype(str).tolist()
     # Restrict to onboarded (we need OHLCV data before options is useful)
     return [s for s in symbols if s in onboarded]
+
+
+def get_etf_symbols(onboarded: set[str]) -> list[str]:
+    """
+    Return sector and broad-market ETF symbols that are in the onboarded set,
+    in the order defined in etf_config (sector ETFs first, then broad ETFs).
+    """
+    from market_data.etf_config import ALL_ETFS  # noqa: PLC0415
+    return [s for s in ALL_ETFS if s in onboarded]
 
 
 # ---------------------------------------------------------------------------
@@ -320,27 +330,32 @@ def main() -> None:
         return
 
     sp500 = get_sp500_symbols(onboarded)
-    if not sp500:
-        print("No SP500 tickers found in onboarded set.")
+    etfs = get_etf_symbols(onboarded)
+    # ETFs first so they're always covered at the start of each cycle.
+    etf_set = set(etfs)
+    all_symbols = etfs + [s for s in sp500 if s not in etf_set]
+
+    if not all_symbols:
+        print("No eligible tickers found in onboarded set.")
         return
 
     # --- Determine batch from cycle state ---
     cycle_done: list[str] = state.get("options_cycle", [])
     cycle_done_set = set(cycle_done)
 
-    pending = [s for s in sp500 if s not in cycle_done_set]
+    pending = [s for s in all_symbols if s not in cycle_done_set]
 
     if not pending:
         # Full cycle complete — reset and start over
-        print(f"Options cycle complete ({len(sp500)} tickers covered). Resetting cycle.")
+        print(f"Options cycle complete ({len(all_symbols)} tickers covered). Resetting cycle.")
         cycle_done = []
         cycle_done_set = set()
-        pending = list(sp500)
+        pending = list(all_symbols)
 
     batch = pending[:args.batch_size]
     remaining_after = len(pending) - len(batch)
 
-    print(f"\nOptions cycle progress: {len(cycle_done_set)}/{len(sp500)} done  "
+    print(f"\nOptions cycle progress: {len(cycle_done_set)}/{len(all_symbols)} done  "
           f"|  {len(pending)} pending  |  processing {len(batch)} this run")
 
     run(symbols=batch, max_expiries=args.max_expiries)
@@ -350,7 +365,7 @@ def main() -> None:
     STATE_FILE.write_text(json.dumps(state, indent=2, default=str))
 
     if remaining_after == 0:
-        print(f"Options cycle complete — all {len(sp500)} SP500 tickers covered.")
+        print(f"Options cycle complete — all {len(all_symbols)} tickers covered.")
     else:
         days_remaining = (remaining_after + args.batch_size - 1) // args.batch_size
         print(f"~{days_remaining} more run(s) to complete this cycle.")

--- a/src/market_data/fetch_tickers.py
+++ b/src/market_data/fetch_tickers.py
@@ -227,6 +227,37 @@ def apply_date_added(
     return result
 
 
+def _inject_etf_rows(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Append rows for sector and broad-market ETFs that are not already present
+    in `df` (the merged constituent DataFrame).
+
+    ETF rows use index = "SECTOR_ETF" or "BROAD_ETF" and NaN market_value
+    (AUM is not comparable to equity market cap and not needed for pipeline
+    operation).  NaN values sort to the bottom of tickers.csv, keeping the
+    constituent stocks at the top.
+    """
+    from market_data.etf_config import SECTOR_ETFS, BROAD_ETFS  # noqa: PLC0415
+
+    existing_symbols: set[str] = set(df["symbol"].dropna())
+
+    new_rows = []
+    for symbol, name in SECTOR_ETFS:
+        if symbol not in existing_symbols:
+            new_rows.append({"symbol": symbol, "name": name,
+                              "market_value": float("nan"), "index": "SECTOR_ETF"})
+    for symbol, name in BROAD_ETFS:
+        if symbol not in existing_symbols:
+            new_rows.append({"symbol": symbol, "name": name,
+                              "market_value": float("nan"), "index": "BROAD_ETF"})
+
+    if not new_rows:
+        return df
+
+    etf_df = pd.DataFrame(new_rows, columns=["symbol", "name", "market_value", "index"])
+    return pd.concat([df, etf_df], ignore_index=True)
+
+
 def run(out_path: Path, today: str | None = None) -> pd.DataFrame:
     """
     Fetch IWM + IVV holdings, merge, apply date_added logic, and write tickers.csv.
@@ -242,6 +273,7 @@ def run(out_path: Path, today: str | None = None) -> pd.DataFrame:
     ivv = clean_holdings(raw_ivv, "SP500")
 
     merged = merge_holdings(iwm, ivv)
+    merged = _inject_etf_rows(merged)
     result = apply_date_added(merged, out_path, today)
 
     if result.empty:

--- a/src/market_data/orchestrator.py
+++ b/src/market_data/orchestrator.py
@@ -16,9 +16,9 @@ Each run executes in order:
                      Auto-skipped if last run was <30 days ago.
 
   4. OPTIONS       — (optional, daily) fetch option chain snapshots (IV, bid/ask,
-                     open interest) for the next batch of SP500 tickers. Processes
-                     50 tickers/run across a ~10-day rolling cycle; cycle state is
-                     tracked in state.json under "options_cycle".
+                     open interest) for the next batch of SP500 + sector/broad ETF
+                     tickers. Processes 50 tickers/run across a rolling cycle; cycle
+                     state is tracked in state.json under "options_cycle".
 
   5. INDICES       — (optional, daily) update VIX, Treasury yields, Fed Funds
                      futures, and S&P 500 index level.
@@ -151,7 +151,10 @@ def maybe_run_fundamentals(
             print(f"  Fundamentals are fresh ({days_since}d old, threshold {FUNDAMENTALS_REFRESH_DAYS}d)")
             return False
 
-    symbols = sorted(onboarded)
+    # ETFs are fund wrappers — their yfinance .info fields don't map to the
+    # equity fundamentals schema (no P/E, margins, analyst targets, etc.).
+    from market_data.etf_config import ALL_ETFS  # noqa: PLC0415
+    symbols = sorted(s for s in onboarded if s not in ALL_ETFS)
     print(f"\nFetching fundamentals for {len(symbols)} tickers "
           f"(last run: {last_raw or 'never'})...")
     try:
@@ -174,7 +177,7 @@ def step_options(
     max_expiries: int,
 ) -> set[str]:
     """
-    Process the next `batch_size` SP500 tickers in the options cycle.
+    Process the next `batch_size` SP500 + ETF tickers in the options cycle.
 
     Returns the updated set of tickers covered in the current cycle so the
     caller can persist it to state.json.
@@ -182,31 +185,37 @@ def step_options(
     from market_data import fetch_options  # noqa: PLC0415
 
     sp500 = fetch_options.get_sp500_symbols(onboarded)
-    if not sp500:
-        print("  OPTIONS  no SP500 tickers in onboarded set — skipping.")
+    etfs = fetch_options.get_etf_symbols(onboarded)
+    # ETFs first so they're always covered at the start of each cycle, then
+    # SP500 constituents (preserving largest-cap-first ordering from tickers.csv).
+    etf_set = set(etfs)
+    all_symbols = etfs + [s for s in sp500 if s not in etf_set]
+
+    if not all_symbols:
+        print("  OPTIONS  no eligible tickers in onboarded set — skipping.")
         return set(state.get("options_cycle", []))
 
     cycle_done: set[str] = set(state.get("options_cycle", []))
-    pending = [s for s in sp500 if s not in cycle_done]
+    pending = [s for s in all_symbols if s not in cycle_done]
 
     if not pending:
-        print(f"  OPTIONS  cycle complete ({len(sp500)} tickers). Resetting cycle.")
+        print(f"  OPTIONS  cycle complete ({len(all_symbols)} tickers). Resetting cycle.")
         cycle_done = set()
-        pending = list(sp500)
+        pending = list(all_symbols)
 
     batch = pending[:batch_size]
     remaining_after = len(pending) - len(batch)
 
     print(f"\n{'='*60}")
     print(f"OPTIONS  {len(batch)} tickers  "
-          f"(cycle: {len(cycle_done)}/{len(sp500)} done, {remaining_after} remaining after this batch)")
+          f"(cycle: {len(cycle_done)}/{len(all_symbols)} done, {remaining_after} remaining after this batch)")
     print(f"{'='*60}")
 
     fetch_options.run(symbols=batch, max_expiries=max_expiries)
 
     updated_cycle = cycle_done | set(batch)
     if remaining_after == 0:
-        print(f"  Options cycle complete — all {len(sp500)} SP500 tickers covered.")
+        print(f"  Options cycle complete — all {len(all_symbols)} tickers covered.")
         return set()  # reset for next cycle
     return updated_cycle
 
@@ -342,15 +351,32 @@ def run(batch_size: int, skip_update: bool, run_merge: bool, run_indices: bool =
     print(f"  Last run         : {last_run or 'never'}")
     print(f"  Last ticker refresh: {state.get('last_ticker_refresh') or 'never'}")
 
-    # --- 1. Onboard new tickers ---
-    newly_onboarded, _failed = step_onboard(pending, batch_size, onboarded)
+    # --- 1a. Priority-onboard ETFs (outside the normal batch limit) ---
+    # ETFs sit at the bottom of tickers.csv (NaN market_value sorts last) so
+    # without this pre-pass they would wait until all ~1,500 stock tickers are
+    # onboarded.  There are at most 19 ETFs, so this adds <2 minutes once.
+    from market_data.etf_config import ALL_ETFS  # noqa: PLC0415
+    etf_pending = [t for t in ALL_ETFS if t not in onboarded and t in set(all_tickers)]
+    etf_newly_onboarded: set[str] = set()
+    if etf_pending:
+        print(f"\n  ETFs pending onboarding: {etf_pending}")
+        etf_newly_onboarded, _ = step_onboard(
+            etf_pending, batch_size=len(etf_pending), onboarded=onboarded
+        )
+        onboarded |= etf_newly_onboarded
+
+    # --- 1b. Onboard new stock tickers (batch-limited, ETFs excluded) ---
+    non_etf_pending = [t for t in pending if t not in set(ALL_ETFS)]
+    newly_onboarded, _failed = step_onboard(non_etf_pending, batch_size, onboarded)
     onboarded |= newly_onboarded
+
+    all_newly_onboarded = etf_newly_onboarded | newly_onboarded
 
     # --- 2. Incremental updates ---
     if not skip_update and last_run:
         # Update tickers that were already onboarded before this run
         # (newly onboarded ones just got full history; no need to update them)
-        to_update = [t for t in all_tickers if t in onboarded and t not in newly_onboarded]
+        to_update = [t for t in all_tickers if t in onboarded and t not in all_newly_onboarded]
         step_update(to_update, since=last_run)
     elif not skip_update and not last_run:
         print("\nUPDATE   skipped — no previous run date in state.json")
@@ -447,7 +473,7 @@ def main() -> None:
         "--options",
         action="store_true",
         help=(
-            "Also run the options chain batch (IV, bid/ask, OI) for SP500 tickers. "
+            "Also run the options chain batch (IV, bid/ask, OI) for SP500 + ETF tickers. "
             f"Processes the next --options-batch-size tickers in the cycle (default: {DEFAULT_OPTIONS_BATCH_SIZE})."
         ),
     )
@@ -456,7 +482,7 @@ def main() -> None:
         type=int,
         default=DEFAULT_OPTIONS_BATCH_SIZE,
         metavar="N",
-        help=f"SP500 tickers to process per options run (default: {DEFAULT_OPTIONS_BATCH_SIZE}).",
+        help=f"Tickers to process per options run (default: {DEFAULT_OPTIONS_BATCH_SIZE}).",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
## Summary

Expands the pipeline to track 19 ETFs alongside the existing Russell 2000 + S&P 500 constituents:

- **11 SPDR Select Sector ETFs**: XLF, XLK, XLE, XLV, XLI, XLP, XLY, XLU, XLB, XLRE, XLC — the canonical sector decomposition of the S&P 500, useful for sector rotation signals and macro regime analysis
- **8 broad-market / asset-class ETFs**: SPY, QQQ, IWM, IVV, DIA, GLD, TLT, HYG — benchmark and cross-asset context for backtests

Each ETF collects **OHLCV history** (same as stocks) and **options chains** (same as SP500 tickers). Fundamentals snapshots are intentionally skipped — yfinance `.info` fields for fund wrappers don't map to the equity schema.

## Changes

**`src/market_data/etf_config.py`** (new)
Central registry of `SECTOR_ETFS`, `BROAD_ETFS`, and `ALL_ETFS`. All other modules import from here, so adding or removing ETFs in the future requires a single-file change.

**`src/market_data/fetch_tickers.py`**
`_inject_etf_rows()` appends ETF rows to `tickers.csv` at ticker-refresh time with `index = "SECTOR_ETF"` or `"BROAD_ETF"`. ETFs get `NaN` market_value so they sort to the bottom of the CSV (stock constituents remain at the top). Idempotent — won't duplicate symbols already present.

**`src/market_data/orchestrator.py`**
- ETFs are **priority-onboarded** at the start of each run, outside the normal `--batch-size` limit. Without this, ETFs would sit behind ~1,500 stock tickers (NaN market_value sorts last). One-time cost is <2 minutes for 19 tickers.
- `maybe_run_fundamentals` now filters `ALL_ETFS` from the symbol list before fetching.
- `step_options` builds the options universe as `[ETFs] + [SP500 not already in ETFs]`, so ETFs are always covered at the start of every cycle.

**`src/market_data/fetch_options.py`**
New `get_etf_symbols(onboarded)` function mirrors the existing `get_sp500_symbols`. The standalone `market-data-fetch-options` CLI uses the same combined symbol list as the orchestrator path.

## Out of scope

ETF holdings collection (top-N holdings, sector weights) is deferred to Phase 2 and documented in `backlog.md`. SSGA and iShares publish daily holdings CSVs that would enable this without any API key.

## Test plan

- [ ] Run `market-data-fetch-tickers` and verify `tickers.csv` contains all 19 ETF rows with correct `index` values (`SECTOR_ETF` / `BROAD_ETF`)
- [ ] Run `market-data-run --batch-size 0` on a state where ETFs are not yet onboarded; confirm "ETFs pending onboarding" log line fires
- [ ] Verify `data/ohlcv/XLF.parquet`, `data/ohlcv/SPY.parquet`, etc. are created with ~10 years of history
- [ ] Run `market-data-run --options` and confirm ETFs appear at the front of the options batch
- [ ] Verify `data/options/XLF.parquet` is created with the correct schema
- [ ] Run `market-data-run --fundamentals` and confirm no ETF symbols appear in the fundamentals fetch output