### PR TITLE
Fix null snapshot_date, symbol, expiry in options data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ All notable changes to this project will be documented here.
 
 ---
 
+## [0.2.4.3] — 2026-04-06
+
+### Fixed
+- `fetch_options.py`: `snapshot_date`, `symbol`, and `expiry` columns were all-null in
+  fetched option chain data. Root cause: constructing a `pd.DataFrame()` empty first, then
+  assigning scalar values column-by-column before any indexed Series column existed.
+  Pandas stored the scalars as zero-row columns; subsequent Series assignments (e.g.
+  `strike`) aligned by index, leaving the scalar columns as NaN. Fixed by replacing the
+  incremental assignments with a single `pd.DataFrame({...})` dict constructor, which
+  correctly broadcasts scalars to the length of the Series values.
+
+---
+
 ## [0.2.4.2] — 2026-04-06
 
 ### Added

--- a/src/market_data/fetch_options.py
+++ b/src/market_data/fetch_options.py
@@ -147,19 +147,20 @@ def fetch_option_chain(symbol: str, max_expiries: int) -> pd.DataFrame:
             if df_raw.empty:
                 continue
 
-            df = pd.DataFrame()
-            df["snapshot_date"] = today
-            df["symbol"] = symbol
-            df["expiry"] = pd.to_datetime(expiry_str).date()
-            df["strike"] = pd.to_numeric(df_raw.get("strike"), errors="coerce")
-            df["option_type"] = side
-            df["last_price"] = pd.to_numeric(df_raw.get("lastPrice"), errors="coerce")
-            df["bid"] = pd.to_numeric(df_raw.get("bid"), errors="coerce")
-            df["ask"] = pd.to_numeric(df_raw.get("ask"), errors="coerce")
-            df["volume"] = pd.to_numeric(df_raw.get("volume"), errors="coerce")
-            df["open_interest"] = pd.to_numeric(df_raw.get("openInterest"), errors="coerce")
-            df["implied_vol"] = pd.to_numeric(df_raw.get("impliedVolatility"), errors="coerce")
-            df["in_the_money"] = df_raw.get("inTheMoney", pd.Series(dtype=bool))
+            df = pd.DataFrame({
+                "snapshot_date": today,
+                "symbol": symbol,
+                "expiry": pd.to_datetime(expiry_str).date(),
+                "strike": pd.to_numeric(df_raw.get("strike"), errors="coerce"),
+                "option_type": side,
+                "last_price": pd.to_numeric(df_raw.get("lastPrice"), errors="coerce"),
+                "bid": pd.to_numeric(df_raw.get("bid"), errors="coerce"),
+                "ask": pd.to_numeric(df_raw.get("ask"), errors="coerce"),
+                "volume": pd.to_numeric(df_raw.get("volume"), errors="coerce"),
+                "open_interest": pd.to_numeric(df_raw.get("openInterest"), errors="coerce"),
+                "implied_vol": pd.to_numeric(df_raw.get("impliedVolatility"), errors="coerce"),
+                "in_the_money": df_raw.get("inTheMoney", pd.Series(dtype=bool)),
+            })
 
             frames.append(df[OPTIONS_COLS])
 


### PR DESCRIPTION
## Summary
- `snapshot_date`, `symbol`, and `expiry` columns were all-null in fetched option chain data
- Root cause: assigning scalars to an empty `pd.DataFrame()` column-by-column before any indexed Series existed, causing index misalignment when the first Series column (`strike`) was added
- Fixed by replacing incremental column assignments with a single `pd.DataFrame({...})` dict constructor, which correctly broadcasts scalars to match Series length

## Test plan
- [ ] Run `market-data-fetch-options --symbols AAPL --max-expiries 1` and verify `snapshot_date`, `symbol`, and `expiry` are non-null in `data/options/AAPL.parquet`