### PR TITLE
Add CI and test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install package with dev dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run tests
+        run: python -m pytest --tb=short
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dev dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run ruff
+        run: ruff check src/ tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,21 @@ market-data-fetch-macro         = "market_data.fetch_macro:main"
 market-data-fetch-fundamentals  = "market_data.fetch_fundamentals:main"
 market-data-fetch-options       = "market_data.fetch_options:main"
 
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.0",
+  "pytest-mock>=3.14",
+  "pytest-cov>=5.0",
+  "responses>=0.25",
+  "ruff>=0.4",
+]
+
 [tool.setuptools.packages.find]
 where = ["src"]
 
 [tool.setuptools]
 package-dir = {"" = "src"}
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-v --tb=short --cov=src/market_data --cov-report=term-missing"

--- a/src/market_data/verify_onboarding.py
+++ b/src/market_data/verify_onboarding.py
@@ -100,7 +100,7 @@ def main() -> None:
             print(f"\nFixed: removed {removed} ghost(s) from {state_file}.")
             print("Run the pipeline to re-onboard them.")
     elif ghosts:
-        print(f"\nRun with --fix to remove ghost(s) from state.json.")
+        print("\nRun with --fix to remove ghost(s) from state.json.")
 
 
 if __name__ == "__main__":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,110 @@
+"""
+Shared pytest fixtures for the market_data test suite.
+All fixtures reflect the real production schemas used in the pipeline.
+"""
+
+from datetime import date
+
+import pandas as pd
+import pytest
+
+
+@pytest.fixture
+def ohlcv_df():
+    """Standard OHLCV DataFrame matching the fetch.py OHLCV_COLS schema."""
+    return pd.DataFrame(
+        {
+            "date": [date(2024, 1, 2), date(2024, 1, 3)],
+            "symbol": ["AAPL", "AAPL"],
+            "open": [185.0, 186.0],
+            "high": [187.0, 188.0],
+            "low": [184.0, 185.0],
+            "close": [186.5, 187.0],
+            "volume": [50_000_000.0, 45_000_000.0],
+        }
+    )
+
+
+@pytest.fixture
+def fundamentals_df():
+    """One-row fundamentals snapshot matching fetch_fundamentals.py SCHEMA_COLS."""
+    return pd.DataFrame(
+        {
+            "as_of": [date(2024, 1, 31)],
+            "symbol": ["AAPL"],
+            "market_cap": [3_000_000_000_000.0],
+            "enterprise_value": [3_100_000_000_000.0],
+            "trailing_pe": [29.5],
+            "forward_pe": [27.0],
+            "price_to_book": [45.0],
+            "trailing_eps": [6.30],
+            "forward_eps": [6.90],
+            "total_revenue": [400_000_000_000.0],
+            "profit_margin": [0.25],
+            "analyst_target_mean": [200.0],
+            "analyst_target_low": [170.0],
+            "analyst_target_high": [230.0],
+            "analyst_recommendation": [1.8],
+            "analyst_count": [42],
+        }
+    )
+
+
+@pytest.fixture
+def holdings_df():
+    """Sample tickers.csv DataFrame matching the fetch_tickers.py schema."""
+    return pd.DataFrame(
+        {
+            "symbol": ["AAPL", "MSFT", "XLF"],
+            "name": ["Apple Inc.", "Microsoft Corp.", "Financial Select Sector SPDR Fund"],
+            "market_value": [3_000_000_000_000.0, 2_800_000_000_000.0, float("nan")],
+            "index": ["SP500", "SP500", "SECTOR_ETF"],
+            "date_added": ["2024-01-01", "2024-01-01", "2024-01-15"],
+        }
+    )
+
+
+@pytest.fixture
+def options_df():
+    """One-row options snapshot matching fetch_options.py OPTIONS_COLS schema."""
+    return pd.DataFrame(
+        {
+            "snapshot_date": [date(2024, 1, 2)],
+            "symbol": ["AAPL"],
+            "expiry": [date(2024, 2, 16)],
+            "strike": [190.0],
+            "option_type": ["call"],
+            "last_price": [5.50],
+            "bid": [5.40],
+            "ask": [5.60],
+            "volume": [1_000.0],
+            "open_interest": [5_000.0],
+            "implied_vol": [0.25],
+            "in_the_money": [False],
+        }
+    )
+
+
+@pytest.fixture
+def raw_yfinance_df():
+    """
+    Simulates the output of yf.Ticker(symbol).history() — a DataFrame with a
+    timezone-aware DatetimeTZIndex and mixed-case single-level columns.
+
+    Used to test _normalize() against realistic yfinance output.
+    """
+    dates = pd.DatetimeIndex(
+        ["2024-01-02", "2024-01-03"], tz="America/New_York"
+    )
+    return pd.DataFrame(
+        {
+            "Open": [185.0, 186.0],
+            "High": [187.0, 188.0],
+            "Low": [184.0, 185.0],
+            "Close": [186.5, 187.0],
+            "Volume": [50_000_000.0, 45_000_000.0],
+            "Dividends": [0.0, 0.0],
+            "Stock Splits": [0.0, 0.0],
+        },
+        index=dates,
+    )

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -1,0 +1,243 @@
+"""
+Tests for fetch.py: _normalize(), save_ticker_data(), load_ticker_data().
+
+No network calls are made; all yfinance interactions are tested via fixtures
+that replicate the real DataFrame shapes yfinance returns.
+"""
+
+from datetime import date
+
+import pandas as pd
+import pytest
+
+from market_data.fetch import (
+    OHLCV_COLS,
+    _normalize,
+    load_ticker_data,
+    save_ticker_data,
+)
+
+
+# ---------------------------------------------------------------------------
+# _normalize()
+# ---------------------------------------------------------------------------
+
+
+class TestNormalize:
+    def test_standard_yfinance_output(self, raw_yfinance_df):
+        """_normalize handles a TZ-aware DatetimeTZIndex and mixed-case columns."""
+        result = _normalize(raw_yfinance_df, "AAPL")
+
+        assert list(result.columns) == OHLCV_COLS
+        assert len(result) == 2
+        assert (result["symbol"] == "AAPL").all()
+        assert result["close"].iloc[0] == pytest.approx(186.5)
+        assert result["close"].iloc[1] == pytest.approx(187.0)
+
+    def test_dates_are_plain_date_objects(self, raw_yfinance_df):
+        """After normalization every value in the date column is a datetime.date."""
+        result = _normalize(raw_yfinance_df, "AAPL")
+        assert all(isinstance(d, date) for d in result["date"])
+
+    def test_extra_columns_stripped(self, raw_yfinance_df):
+        """Columns like 'Dividends' and 'Stock Splits' are dropped."""
+        result = _normalize(raw_yfinance_df, "AAPL")
+        assert set(result.columns) == set(OHLCV_COLS)
+
+    def test_empty_returns_empty_with_schema(self):
+        """_normalize of an empty DataFrame returns empty with correct columns."""
+        result = _normalize(pd.DataFrame(), "AAPL")
+        assert result.empty
+        assert list(result.columns) == OHLCV_COLS
+
+    def test_multiindex_columns_flattened(self):
+        """MultiIndex columns from yf.download multi-ticker calls are flattened."""
+        dates = pd.DatetimeIndex(["2024-01-02"], tz="UTC")
+        cols = pd.MultiIndex.from_tuples(
+            [
+                ("Open", "SPY"),
+                ("High", "SPY"),
+                ("Low", "SPY"),
+                ("Close", "SPY"),
+                ("Volume", "SPY"),
+            ]
+        )
+        df = pd.DataFrame(
+            [[450.0, 452.0, 449.0, 451.0, 80_000_000.0]],
+            index=dates,
+            columns=cols,
+        )
+        result = _normalize(df, "SPY")
+        assert list(result.columns) == OHLCV_COLS
+        assert result["close"].iloc[0] == pytest.approx(451.0)
+
+    def test_drops_rows_without_close(self):
+        """Rows where Close is NaN are removed."""
+        dates = pd.DatetimeIndex(["2024-01-02", "2024-01-03"])
+        df = pd.DataFrame(
+            {
+                "Open": [100.0, 101.0],
+                "High": [102.0, 103.0],
+                "Low": [99.0, 100.0],
+                "Close": [101.0, float("nan")],
+                "Volume": [1_000_000.0, 1_100_000.0],
+            },
+            index=dates,
+        )
+        result = _normalize(df, "TEST")
+        assert len(result) == 1
+        assert result["close"].iloc[0] == pytest.approx(101.0)
+
+    def test_tolerates_missing_volume_column(self):
+        """_normalize works when Volume is absent — only available columns returned."""
+        dates = pd.DatetimeIndex(["2024-01-02"])
+        df = pd.DataFrame(
+            {"Open": [100.0], "High": [102.0], "Low": [99.0], "Close": [101.0]},
+            index=dates,
+        )
+        result = _normalize(df, "TEST")
+        assert "close" in result.columns
+        assert "volume" not in result.columns
+
+    def test_strips_timezone_from_index(self):
+        """Dates have no timezone info after normalization."""
+        dates = pd.DatetimeIndex(["2024-01-02"], tz="US/Eastern")
+        df = pd.DataFrame(
+            {"Open": [100.0], "High": [102.0], "Low": [99.0], "Close": [101.0], "Volume": [1e6]},
+            index=dates,
+        )
+        result = _normalize(df, "TEST")
+        # date objects have no tzinfo attribute — just confirm they are plain dates
+        assert isinstance(result["date"].iloc[0], date)
+
+    def test_symbol_column_set_correctly(self, raw_yfinance_df):
+        """The symbol column is populated with the provided symbol string."""
+        result = _normalize(raw_yfinance_df, "XLF")
+        assert (result["symbol"] == "XLF").all()
+
+    def test_index_reset_after_normalize(self, raw_yfinance_df):
+        """The resulting DataFrame has a clean 0-based integer index."""
+        result = _normalize(raw_yfinance_df, "AAPL")
+        assert list(result.index) == list(range(len(result)))
+
+
+# ---------------------------------------------------------------------------
+# save_ticker_data() + load_ticker_data()
+# ---------------------------------------------------------------------------
+
+
+class TestSaveTickerData:
+    def test_creates_new_file(self, ohlcv_df, tmp_path):
+        data_dir = tmp_path / "ohlcv"
+        rows_added = save_ticker_data("AAPL", ohlcv_df, data_dir)
+
+        assert rows_added == 2
+        assert (data_dir / "AAPL.parquet").exists()
+
+    def test_returns_zero_for_empty_df(self, tmp_path):
+        data_dir = tmp_path / "ohlcv"
+        empty = pd.DataFrame(columns=OHLCV_COLS)
+        assert save_ticker_data("AAPL", empty, data_dir) == 0
+        assert not (data_dir / "AAPL.parquet").exists()
+
+    def test_idempotent_on_duplicate_rows(self, ohlcv_df, tmp_path):
+        """Saving the same data twice results in zero additional rows."""
+        data_dir = tmp_path / "ohlcv"
+        save_ticker_data("AAPL", ohlcv_df, data_dir)
+        added = save_ticker_data("AAPL", ohlcv_df, data_dir)
+
+        assert added == 0
+        stored = load_ticker_data("AAPL", data_dir)
+        assert len(stored) == 2
+
+    def test_appends_new_rows(self, ohlcv_df, tmp_path):
+        data_dir = tmp_path / "ohlcv"
+        save_ticker_data("AAPL", ohlcv_df, data_dir)
+
+        new_row = pd.DataFrame(
+            {
+                "date": [date(2024, 1, 4)],
+                "symbol": ["AAPL"],
+                "open": [188.0],
+                "high": [190.0],
+                "low": [187.0],
+                "close": [189.0],
+                "volume": [55_000_000.0],
+            }
+        )
+        added = save_ticker_data("AAPL", new_row, data_dir)
+
+        assert added == 1
+        stored = load_ticker_data("AAPL", data_dir)
+        assert len(stored) == 3
+
+    def test_deduplicates_overlap(self, ohlcv_df, tmp_path):
+        """When new_df overlaps existing on (date, symbol), duplicates are dropped."""
+        data_dir = tmp_path / "ohlcv"
+        save_ticker_data("AAPL", ohlcv_df, data_dir)
+
+        # 2024-01-02 already stored; 2024-01-05 is genuinely new
+        overlap = pd.DataFrame(
+            {
+                "date": [date(2024, 1, 2), date(2024, 1, 5)],
+                "symbol": ["AAPL", "AAPL"],
+                "open": [999.0, 190.0],
+                "high": [999.0, 192.0],
+                "low": [999.0, 189.0],
+                "close": [999.0, 191.0],
+                "volume": [1.0, 60_000_000.0],
+            }
+        )
+        added = save_ticker_data("AAPL", overlap, data_dir)
+
+        assert added == 1
+        stored = load_ticker_data("AAPL", data_dir)
+        assert len(stored) == 3
+
+    def test_creates_parent_dir(self, ohlcv_df, tmp_path):
+        """save_ticker_data creates missing parent directories automatically."""
+        data_dir = tmp_path / "deep" / "nested" / "ohlcv"
+        save_ticker_data("AAPL", ohlcv_df, data_dir)
+        assert (data_dir / "AAPL.parquet").exists()
+
+    def test_sorted_by_date_ascending(self, tmp_path):
+        """Stored data is always sorted by date ascending."""
+        data_dir = tmp_path / "ohlcv"
+        df = pd.DataFrame(
+            {
+                "date": [date(2024, 1, 3), date(2024, 1, 2)],  # out of order
+                "symbol": ["AAPL", "AAPL"],
+                "open": [186.0, 185.0],
+                "high": [188.0, 187.0],
+                "low": [185.0, 184.0],
+                "close": [187.0, 186.5],
+                "volume": [45e6, 50e6],
+            }
+        )
+        save_ticker_data("AAPL", df, data_dir)
+        stored = load_ticker_data("AAPL", data_dir)
+        dates = list(stored["date"])
+        assert dates == sorted(dates)
+
+
+class TestLoadTickerData:
+    def test_returns_none_for_missing_file(self, tmp_path):
+        result = load_ticker_data("NONEXISTENT", tmp_path / "ohlcv")
+        assert result is None
+
+    def test_round_trip_columns(self, ohlcv_df, tmp_path):
+        data_dir = tmp_path / "ohlcv"
+        save_ticker_data("AAPL", ohlcv_df, data_dir)
+        loaded = load_ticker_data("AAPL", data_dir)
+
+        assert loaded is not None
+        assert list(loaded.columns) == list(ohlcv_df.columns)
+
+    def test_round_trip_values(self, ohlcv_df, tmp_path):
+        data_dir = tmp_path / "ohlcv"
+        save_ticker_data("AAPL", ohlcv_df, data_dir)
+        loaded = load_ticker_data("AAPL", data_dir)
+
+        assert len(loaded) == 2
+        assert loaded["close"].iloc[0] == pytest.approx(186.5)
+        assert loaded["close"].iloc[1] == pytest.approx(187.0)

--- a/tests/test_fetch_tickers.py
+++ b/tests/test_fetch_tickers.py
@@ -1,0 +1,441 @@
+"""
+Tests for fetch_tickers.py:
+  - clean_holdings()     — filtering, corrections, market-value parsing
+  - apply_date_added()   — date preservation and new-ticker assignment
+  - merge_holdings()     — dedup strategy for IWM/IVV overlap
+  - _inject_etf_rows()   — idempotency and ETF label correctness
+"""
+
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from market_data.fetch_tickers import (
+    _inject_etf_rows,
+    apply_date_added,
+    clean_holdings,
+    merge_holdings,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _raw_holdings(tickers, names, market_values, asset_classes=None):
+    """Build a minimal iShares-style raw holdings DataFrame."""
+    n = len(tickers)
+    return pd.DataFrame(
+        {
+            "Ticker": tickers,
+            "Name": names,
+            "Market Value": market_values,
+            "Asset Class": asset_classes if asset_classes else ["Equity"] * n,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# clean_holdings()
+# ---------------------------------------------------------------------------
+
+
+class TestCleanHoldings:
+    def test_output_columns(self):
+        raw = _raw_holdings(["AAPL"], ["Apple Inc."], ["$1,000,000.00"])
+        result = clean_holdings(raw, "SP500")
+        assert list(result.columns) == ["symbol", "name", "market_value", "index"]
+
+    def test_index_label_applied(self):
+        raw = _raw_holdings(["AAPL", "MSFT"], ["Apple", "Microsoft"], ["$1,000.00", "$900.00"])
+        result = clean_holdings(raw, "RUT2000")
+        assert (result["index"] == "RUT2000").all()
+
+    def test_excludes_non_equity_asset_class(self):
+        raw = _raw_holdings(
+            ["AAPL", "CASH"],
+            ["Apple", "Cash Component"],
+            ["$1,000,000.00", "$0.00"],
+            asset_classes=["Equity", "Cash"],
+        )
+        result = clean_holdings(raw, "SP500")
+        assert set(result["symbol"]) == {"AAPL"}
+
+    def test_excludes_dash_placeholder_tickers(self):
+        raw = _raw_holdings(
+            ["AAPL", "-", ""],
+            ["Apple", "Placeholder", "Blank"],
+            ["$1,000,000.00", "$0.00", "$0.00"],
+        )
+        result = clean_holdings(raw, "SP500")
+        assert set(result["symbol"]) == {"AAPL"}
+
+    def test_excludes_cvr_names(self):
+        raw = _raw_holdings(
+            ["AAPL", "FAKECVR"],
+            ["Apple Inc.", "CVR for SomeCo Acquisition"],
+            ["$1,000,000.00", "$100.00"],
+        )
+        result = clean_holdings(raw, "SP500")
+        assert set(result["symbol"]) == {"AAPL"}
+
+    def test_excludes_rights_names(self):
+        raw = _raw_holdings(
+            ["AAPL", "FAKERIGHTS"],
+            ["Apple Inc.", "Common RIGHTS of XYZ Corp"],
+            ["$1,000,000.00", "$50.00"],
+        )
+        result = clean_holdings(raw, "SP500")
+        assert set(result["symbol"]) == {"AAPL"}
+
+    def test_excludes_warrant_names(self):
+        raw = _raw_holdings(
+            ["AAPL", "FAKEWT"],
+            ["Apple Inc.", "WARRANT Series B"],
+            ["$1,000,000.00", "$50.00"],
+        )
+        result = clean_holdings(raw, "SP500")
+        assert set(result["symbol"]) == {"AAPL"}
+
+    def test_excludes_escrow_names(self):
+        raw = _raw_holdings(
+            ["AAPL", "FAKEESC"],
+            ["Apple Inc.", "Escrow shares of OldCo"],
+            ["$1,000,000.00", "$10.00"],
+        )
+        result = clean_holdings(raw, "SP500")
+        assert set(result["symbol"]) == {"AAPL"}
+
+    def test_ticker_correction_brkb(self):
+        raw = _raw_holdings(["BRKB", "AAPL"], ["Berkshire", "Apple"], ["$500,000.00", "$1,000,000.00"])
+        result = clean_holdings(raw, "SP500")
+        assert "BRK-B" in result["symbol"].values
+        assert "BRKB" not in result["symbol"].values
+
+    def test_ticker_correction_bfb(self):
+        raw = _raw_holdings(["BFB", "AAPL"], ["Brown-Forman B", "Apple"], ["$200,000.00", "$1,000,000.00"])
+        result = clean_holdings(raw, "SP500")
+        assert "BF-B" in result["symbol"].values
+
+    def test_parses_market_value_with_dollar_and_commas(self):
+        raw = _raw_holdings(["AAPL"], ["Apple"], ["$1,234,567.89"])
+        result = clean_holdings(raw, "SP500")
+        assert result["market_value"].iloc[0] == pytest.approx(1_234_567.89)
+
+    def test_sorts_by_market_value_descending(self):
+        raw = _raw_holdings(
+            ["SMALL", "BIG", "MED"],
+            ["Small", "Big", "Med"],
+            ["$100.00", "$1,000,000.00", "$50,000.00"],
+        )
+        result = clean_holdings(raw, "SP500")
+        values = list(result["market_value"])
+        assert values == sorted(values, reverse=True)
+
+    def test_missing_market_value_column_gives_nan(self):
+        df = pd.DataFrame({"Ticker": ["AAPL"], "Name": ["Apple"], "Asset Class": ["Equity"]})
+        result = clean_holdings(df, "SP500")
+        assert pd.isna(result["market_value"].iloc[0])
+
+
+# ---------------------------------------------------------------------------
+# apply_date_added()
+# ---------------------------------------------------------------------------
+
+
+class TestApplyDateAdded:
+    def test_all_new_get_today_when_no_existing_file(self, tmp_path):
+        new_df = pd.DataFrame(
+            {
+                "symbol": ["AAPL", "MSFT"],
+                "name": ["Apple", "Microsoft"],
+                "market_value": [1_000_000.0, 900_000.0],
+                "index": ["SP500", "SP500"],
+            }
+        )
+        result = apply_date_added(new_df, tmp_path / "nonexistent.csv", "2024-01-15")
+        assert (result["date_added"] == "2024-01-15").all()
+
+    def test_existing_symbol_preserves_original_date(self, tmp_path):
+        existing = pd.DataFrame(
+            {
+                "symbol": ["AAPL"],
+                "name": ["Apple"],
+                "market_value": [1_000_000.0],
+                "index": ["SP500"],
+                "date_added": ["2023-06-01"],
+            }
+        )
+        csv_path = tmp_path / "tickers.csv"
+        existing.to_csv(csv_path, index=False)
+
+        new_df = pd.DataFrame(
+            {
+                "symbol": ["AAPL"],
+                "name": ["Apple Inc."],
+                "market_value": [1_100_000.0],
+                "index": ["SP500"],
+            }
+        )
+        result = apply_date_added(new_df, csv_path, "2024-01-15")
+        assert result.loc[result["symbol"] == "AAPL", "date_added"].iloc[0] == "2023-06-01"
+
+    def test_new_symbol_gets_today(self, tmp_path):
+        existing = pd.DataFrame(
+            {
+                "symbol": ["AAPL"],
+                "name": ["Apple"],
+                "market_value": [1_000_000.0],
+                "index": ["SP500"],
+                "date_added": ["2023-06-01"],
+            }
+        )
+        csv_path = tmp_path / "tickers.csv"
+        existing.to_csv(csv_path, index=False)
+
+        new_df = pd.DataFrame(
+            {
+                "symbol": ["AAPL", "MSFT"],  # MSFT is brand-new
+                "name": ["Apple", "Microsoft"],
+                "market_value": [1_000_000.0, 900_000.0],
+                "index": ["SP500", "SP500"],
+            }
+        )
+        result = apply_date_added(new_df, csv_path, "2024-01-15")
+        assert result.loc[result["symbol"] == "MSFT", "date_added"].iloc[0] == "2024-01-15"
+
+    def test_dropped_ticker_carried_forward(self, tmp_path):
+        """Tickers that left both indices are still present in the output."""
+        existing = pd.DataFrame(
+            {
+                "symbol": ["AAPL", "DROPPED"],
+                "name": ["Apple", "Dropped Corp"],
+                "market_value": [1_000_000.0, 50_000.0],
+                "index": ["SP500", "SP500"],
+                "date_added": ["2023-01-01", "2022-01-01"],
+            }
+        )
+        csv_path = tmp_path / "tickers.csv"
+        existing.to_csv(csv_path, index=False)
+
+        new_df = pd.DataFrame(
+            {
+                "symbol": ["AAPL"],  # DROPPED not included
+                "name": ["Apple Inc."],
+                "market_value": [1_100_000.0],
+                "index": ["SP500"],
+            }
+        )
+        result = apply_date_added(new_df, csv_path, "2024-01-15")
+        assert "DROPPED" in result["symbol"].values
+
+    def test_backfill_missing_date_added_column(self, tmp_path):
+        """Old CSV without date_added column gets backfilled with '2000-01-01'."""
+        existing = pd.DataFrame(
+            {
+                "symbol": ["AAPL"],
+                "name": ["Apple"],
+                "market_value": [1_000_000.0],
+                "index": ["SP500"],
+                # no date_added column
+            }
+        )
+        csv_path = tmp_path / "tickers.csv"
+        existing.to_csv(csv_path, index=False)
+
+        new_df = pd.DataFrame(
+            {
+                "symbol": ["AAPL"],
+                "name": ["Apple"],
+                "market_value": [1_000_000.0],
+                "index": ["SP500"],
+            }
+        )
+        result = apply_date_added(new_df, csv_path, "2024-01-15")
+        # AAPL was in old CSV, so it gets the backfilled date, not today
+        assert result.loc[result["symbol"] == "AAPL", "date_added"].iloc[0] == "2000-01-01"
+
+    def test_no_duplicate_symbols_in_output(self, tmp_path):
+        """The output should not contain duplicate symbols."""
+        existing = pd.DataFrame(
+            {
+                "symbol": ["AAPL"],
+                "name": ["Apple"],
+                "market_value": [1_000_000.0],
+                "index": ["SP500"],
+                "date_added": ["2023-01-01"],
+            }
+        )
+        csv_path = tmp_path / "tickers.csv"
+        existing.to_csv(csv_path, index=False)
+
+        new_df = pd.DataFrame(
+            {
+                "symbol": ["AAPL"],
+                "name": ["Apple Inc."],
+                "market_value": [1_100_000.0],
+                "index": ["SP500"],
+            }
+        )
+        result = apply_date_added(new_df, csv_path, "2024-01-15")
+        assert result["symbol"].nunique() == len(result)
+
+
+# ---------------------------------------------------------------------------
+# merge_holdings()
+# ---------------------------------------------------------------------------
+
+
+class TestMergeHoldings:
+    def test_each_symbol_appears_once(self):
+        iwm = pd.DataFrame(
+            {
+                "symbol": ["SHARED", "SMALL"],
+                "name": ["Shared Corp", "Small Corp"],
+                "market_value": [500_000.0, 100_000.0],
+                "index": ["RUT2000", "RUT2000"],
+            }
+        )
+        ivv = pd.DataFrame(
+            {
+                "symbol": ["SHARED", "BIG"],
+                "name": ["Shared Corp IVV", "Big Corp"],
+                "market_value": [600_000.0, 1_000_000.0],
+                "index": ["SP500", "SP500"],
+            }
+        )
+        result = merge_holdings(iwm, ivv)
+        assert result["symbol"].value_counts().max() == 1
+
+    def test_overlap_uses_max_market_value(self):
+        iwm = pd.DataFrame(
+            {"symbol": ["SHARED"], "name": ["Shared"], "market_value": [400_000.0], "index": ["RUT2000"]}
+        )
+        ivv = pd.DataFrame(
+            {"symbol": ["SHARED"], "name": ["Shared"], "market_value": [600_000.0], "index": ["SP500"]}
+        )
+        result = merge_holdings(iwm, ivv)
+        mv = result.loc[result["symbol"] == "SHARED", "market_value"].iloc[0]
+        assert mv == pytest.approx(600_000.0)
+
+    def test_overlap_index_label_combined(self):
+        iwm = pd.DataFrame(
+            {"symbol": ["SHARED"], "name": ["S"], "market_value": [500_000.0], "index": ["RUT2000"]}
+        )
+        ivv = pd.DataFrame(
+            {"symbol": ["SHARED"], "name": ["S"], "market_value": [600_000.0], "index": ["SP500"]}
+        )
+        result = merge_holdings(iwm, ivv)
+        idx_label = result.loc[result["symbol"] == "SHARED", "index"].iloc[0]
+        assert idx_label == "SP500,RUT2000"
+
+    def test_non_overlap_keeps_original_index(self):
+        iwm = pd.DataFrame(
+            {"symbol": ["SMALL"], "name": ["Small"], "market_value": [100_000.0], "index": ["RUT2000"]}
+        )
+        ivv = pd.DataFrame(
+            {"symbol": ["BIG"], "name": ["Big"], "market_value": [1_000_000.0], "index": ["SP500"]}
+        )
+        result = merge_holdings(iwm, ivv)
+        assert result.loc[result["symbol"] == "SMALL", "index"].iloc[0] == "RUT2000"
+        assert result.loc[result["symbol"] == "BIG", "index"].iloc[0] == "SP500"
+
+    def test_sorted_by_market_value_descending(self):
+        iwm = pd.DataFrame(
+            {"symbol": ["SMALL"], "name": ["Small"], "market_value": [100_000.0], "index": ["RUT2000"]}
+        )
+        ivv = pd.DataFrame(
+            {"symbol": ["BIG"], "name": ["Big"], "market_value": [1_000_000.0], "index": ["SP500"]}
+        )
+        result = merge_holdings(iwm, ivv)
+        assert result["symbol"].iloc[0] == "BIG"
+
+    def test_output_columns(self):
+        iwm = pd.DataFrame(
+            {"symbol": ["A"], "name": ["A Corp"], "market_value": [100.0], "index": ["RUT2000"]}
+        )
+        ivv = pd.DataFrame(
+            {"symbol": ["B"], "name": ["B Corp"], "market_value": [200.0], "index": ["SP500"]}
+        )
+        result = merge_holdings(iwm, ivv)
+        assert set(result.columns) == {"symbol", "name", "market_value", "index"}
+
+
+# ---------------------------------------------------------------------------
+# _inject_etf_rows()
+# ---------------------------------------------------------------------------
+
+
+class TestInjectEtfRows:
+    def test_injects_sector_etf_rows(self):
+        df = pd.DataFrame(
+            {
+                "symbol": ["AAPL"],
+                "name": ["Apple Inc."],
+                "market_value": [1_000_000.0],
+                "index": ["SP500"],
+            }
+        )
+        result = _inject_etf_rows(df)
+        sector_rows = result[result["index"] == "SECTOR_ETF"]
+        assert len(sector_rows) > 0
+
+    def test_injects_broad_etf_rows(self):
+        df = pd.DataFrame(
+            {
+                "symbol": ["AAPL"],
+                "name": ["Apple Inc."],
+                "market_value": [1_000_000.0],
+                "index": ["SP500"],
+            }
+        )
+        result = _inject_etf_rows(df)
+        broad_rows = result[result["index"] == "BROAD_ETF"]
+        assert len(broad_rows) > 0
+
+    def test_idempotent(self):
+        """Calling _inject_etf_rows twice does not create duplicate ETF symbols."""
+        df = pd.DataFrame(
+            {
+                "symbol": ["AAPL"],
+                "name": ["Apple Inc."],
+                "market_value": [1_000_000.0],
+                "index": ["SP500"],
+            }
+        )
+        once = _inject_etf_rows(df)
+        twice = _inject_etf_rows(once)
+
+        assert twice["symbol"].nunique() == len(twice)
+        assert len(twice) == len(once)
+
+    def test_does_not_duplicate_already_present_etf(self):
+        from market_data.etf_config import SECTOR_ETFS
+
+        sym, name = SECTOR_ETFS[0]
+        df = pd.DataFrame(
+            {
+                "symbol": [sym],
+                "name": [name],
+                "market_value": [float("nan")],
+                "index": ["SECTOR_ETF"],
+            }
+        )
+        result = _inject_etf_rows(df)
+        assert (result["symbol"] == sym).sum() == 1
+
+    def test_etf_rows_have_nan_market_value(self):
+        df = pd.DataFrame(
+            {
+                "symbol": ["AAPL"],
+                "name": ["Apple Inc."],
+                "market_value": [1_000_000.0],
+                "index": ["SP500"],
+            }
+        )
+        result = _inject_etf_rows(df)
+        etf_rows = result[result["index"].isin(["SECTOR_ETF", "BROAD_ETF"])]
+        assert etf_rows["market_value"].isna().all()

--- a/tests/test_fetch_tickers.py
+++ b/tests/test_fetch_tickers.py
@@ -6,8 +6,6 @@ Tests for fetch_tickers.py:
   - _inject_etf_rows()   — idempotency and ETF label correctness
 """
 
-from datetime import date
-from pathlib import Path
 
 import pandas as pd
 import pytest

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,0 +1,170 @@
+"""
+Tests for merge.py: run() with multiple tmp parquets.
+
+Verifies correct row count, deduplication, sort order, and atomic-write
+behaviour without touching any real data directories.
+"""
+
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from market_data import merge
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ohlcv(symbol: str, dates: list, prices: list) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "date": dates,
+            "symbol": [symbol] * len(dates),
+            "open": prices,
+            "high": [p + 1.0 for p in prices],
+            "low": [p - 1.0 for p in prices],
+            "close": prices,
+            "volume": [1_000_000.0] * len(dates),
+        }
+    )
+
+
+DATES_2 = [date(2024, 1, 2), date(2024, 1, 3)]
+DATES_3 = [date(2024, 1, 2), date(2024, 1, 3), date(2024, 1, 4)]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestMergeRun:
+    def test_merges_two_ticker_files(self, tmp_path):
+        data_dir = tmp_path / "ohlcv"
+        data_dir.mkdir()
+        out = tmp_path / "merged.parquet"
+
+        _make_ohlcv("AAPL", DATES_2, [185.0, 186.0]).to_parquet(
+            data_dir / "AAPL.parquet", index=False
+        )
+        _make_ohlcv("MSFT", DATES_2, [375.0, 376.0]).to_parquet(
+            data_dir / "MSFT.parquet", index=False
+        )
+
+        merge.run(data_dir=data_dir, out=out)
+
+        result = pd.read_parquet(out)
+        assert len(result) == 4  # 2 symbols × 2 dates
+
+    def test_combined_row_count_three_symbols(self, tmp_path):
+        data_dir = tmp_path / "ohlcv"
+        data_dir.mkdir()
+        out = tmp_path / "merged.parquet"
+
+        for sym in ["AAPL", "MSFT", "GOOGL"]:
+            _make_ohlcv(sym, DATES_3, [100.0, 101.0, 102.0]).to_parquet(
+                data_dir / f"{sym}.parquet", index=False
+            )
+
+        merge.run(data_dir=data_dir, out=out)
+        result = pd.read_parquet(out)
+        assert len(result) == 3 * len(DATES_3)
+
+    def test_deduplicates_on_date_symbol(self, tmp_path):
+        """If the same (date, symbol) appears in two files, only one row survives."""
+        data_dir = tmp_path / "ohlcv"
+        data_dir.mkdir()
+        out = tmp_path / "merged.parquet"
+
+        df = _make_ohlcv("AAPL", [date(2024, 1, 2)], [185.0])
+        # Write identical data to two separate files to simulate overlap
+        df.to_parquet(data_dir / "AAPL.parquet", index=False)
+        df.to_parquet(data_dir / "AAPL_dup.parquet", index=False)
+
+        merge.run(data_dir=data_dir, out=out)
+        result = pd.read_parquet(out)
+        assert len(result) == 1
+
+    def test_sorted_by_date_then_symbol(self, tmp_path):
+        data_dir = tmp_path / "ohlcv"
+        data_dir.mkdir()
+        out = tmp_path / "merged.parquet"
+
+        _make_ohlcv("ZZZ", DATES_2, [100.0, 101.0]).to_parquet(
+            data_dir / "ZZZ.parquet", index=False
+        )
+        _make_ohlcv("AAA", DATES_2, [200.0, 201.0]).to_parquet(
+            data_dir / "AAA.parquet", index=False
+        )
+
+        merge.run(data_dir=data_dir, out=out)
+        result = pd.read_parquet(out)
+
+        # Within the same date, symbols should be alphabetically ordered
+        same_date = result[result["date"] == DATES_2[0]]
+        assert list(same_date["symbol"]) == ["AAA", "ZZZ"]
+
+    def test_output_file_created(self, tmp_path):
+        data_dir = tmp_path / "ohlcv"
+        data_dir.mkdir()
+        out = tmp_path / "merged.parquet"
+
+        _make_ohlcv("AAPL", DATES_2, [185.0, 186.0]).to_parquet(
+            data_dir / "AAPL.parquet", index=False
+        )
+        merge.run(data_dir=data_dir, out=out)
+        assert out.exists()
+
+    def test_empty_dir_does_not_create_output(self, tmp_path):
+        data_dir = tmp_path / "ohlcv"
+        data_dir.mkdir()
+        out = tmp_path / "merged.parquet"
+
+        merge.run(data_dir=data_dir, out=out)
+        assert not out.exists()
+
+    def test_output_has_correct_columns(self, tmp_path):
+        data_dir = tmp_path / "ohlcv"
+        data_dir.mkdir()
+        out = tmp_path / "merged.parquet"
+
+        _make_ohlcv("AAPL", DATES_2, [185.0, 186.0]).to_parquet(
+            data_dir / "AAPL.parquet", index=False
+        )
+        merge.run(data_dir=data_dir, out=out)
+        result = pd.read_parquet(out)
+        assert set(result.columns) == {"date", "symbol", "open", "high", "low", "close", "volume"}
+
+    def test_existing_merged_file_not_included_in_sources(self, tmp_path):
+        """The merged output file itself must not be read back in as a source."""
+        data_dir = tmp_path / "ohlcv"
+        data_dir.mkdir()
+        out = data_dir / "merged.parquet"  # place merged inside data_dir
+
+        _make_ohlcv("AAPL", DATES_2, [185.0, 186.0]).to_parquet(
+            data_dir / "AAPL.parquet", index=False
+        )
+        # First pass — creates merged.parquet inside data_dir
+        merge.run(data_dir=data_dir, out=out)
+        first_count = len(pd.read_parquet(out))
+
+        # Second pass — merged.parquet now exists; should not be double-counted
+        merge.run(data_dir=data_dir, out=out)
+        second_count = len(pd.read_parquet(out))
+
+        assert first_count == second_count
+
+    def test_creates_parent_dir_for_output(self, tmp_path):
+        data_dir = tmp_path / "ohlcv"
+        data_dir.mkdir()
+        out = tmp_path / "deep" / "nested" / "merged.parquet"
+
+        _make_ohlcv("AAPL", DATES_2, [185.0, 186.0]).to_parquet(
+            data_dir / "AAPL.parquet", index=False
+        )
+        merge.run(data_dir=data_dir, out=out)
+        assert out.exists()

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -6,10 +6,8 @@ behaviour without touching any real data directories.
 """
 
 from datetime import date
-from pathlib import Path
 
 import pandas as pd
-import pytest
 
 from market_data import merge
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,197 @@
+"""
+Tests for orchestrator.py: load_state(), save_state(), load_ordered_tickers().
+
+All tests use monkeypatching and tmp_path to avoid touching real files.
+No network calls or pipeline steps are exercised here.
+"""
+
+import json
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+import market_data.orchestrator as orchestrator
+
+
+# ---------------------------------------------------------------------------
+# load_state() / save_state()
+# ---------------------------------------------------------------------------
+
+
+class TestLoadState:
+    def test_returns_defaults_when_no_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(orchestrator, "STATE_FILE", tmp_path / "state.json")
+        state = orchestrator.load_state()
+
+        assert state["onboarded"] == []
+        assert state["last_run"] is None
+        assert state["last_ticker_refresh"] is None
+        assert state["last_fundamentals_run"] is None
+        assert state["options_cycle"] == []
+
+    def test_reads_onboarded_list(self, tmp_path, monkeypatch):
+        state_file = tmp_path / "state.json"
+        monkeypatch.setattr(orchestrator, "STATE_FILE", state_file)
+        state_file.write_text(json.dumps({"onboarded": ["AAPL", "MSFT"]}))
+
+        state = orchestrator.load_state()
+        assert state["onboarded"] == ["AAPL", "MSFT"]
+
+    def test_handles_partial_state_file(self, tmp_path, monkeypatch):
+        """Missing keys in state.json get sensible defaults."""
+        state_file = tmp_path / "state.json"
+        monkeypatch.setattr(orchestrator, "STATE_FILE", state_file)
+        state_file.write_text(json.dumps({"onboarded": ["AAPL"], "last_run": "2024-01-10"}))
+
+        state = orchestrator.load_state()
+        assert state["onboarded"] == ["AAPL"]
+        assert state["last_run"] == "2024-01-10"
+        assert state["last_ticker_refresh"] is None
+        assert state["options_cycle"] == []
+
+    def test_handles_empty_json_object(self, tmp_path, monkeypatch):
+        state_file = tmp_path / "state.json"
+        monkeypatch.setattr(orchestrator, "STATE_FILE", state_file)
+        state_file.write_text(json.dumps({}))
+
+        state = orchestrator.load_state()
+        assert state["onboarded"] == []
+        assert state["last_run"] is None
+
+
+class TestSaveState:
+    def test_creates_file(self, tmp_path, monkeypatch):
+        state_file = tmp_path / "state.json"
+        monkeypatch.setattr(orchestrator, "STATE_FILE", state_file)
+
+        orchestrator.save_state({"onboarded": ["AAPL"], "last_run": "2024-01-01"})
+        assert state_file.exists()
+
+    def test_written_as_valid_json(self, tmp_path, monkeypatch):
+        state_file = tmp_path / "state.json"
+        monkeypatch.setattr(orchestrator, "STATE_FILE", state_file)
+
+        orchestrator.save_state({"onboarded": ["AAPL"], "last_run": "2024-01-01"})
+        raw = json.loads(state_file.read_text())
+        assert raw["onboarded"] == ["AAPL"]
+        assert raw["last_run"] == "2024-01-01"
+
+    def test_round_trip_full_state(self, tmp_path, monkeypatch):
+        state_file = tmp_path / "state.json"
+        monkeypatch.setattr(orchestrator, "STATE_FILE", state_file)
+
+        original = {
+            "onboarded": ["AAPL", "MSFT", "GOOGL"],
+            "last_run": "2024-03-15",
+            "last_ticker_refresh": "2024-02-10",
+            "last_fundamentals_run": "2024-02-15",
+            "options_cycle": ["AAPL", "MSFT"],
+        }
+        orchestrator.save_state(original)
+        loaded = orchestrator.load_state()
+
+        assert loaded["onboarded"] == original["onboarded"]
+        assert loaded["last_run"] == original["last_run"]
+        assert loaded["last_ticker_refresh"] == original["last_ticker_refresh"]
+        assert loaded["last_fundamentals_run"] == original["last_fundamentals_run"]
+        assert loaded["options_cycle"] == original["options_cycle"]
+
+    def test_overwrites_previous_state(self, tmp_path, monkeypatch):
+        state_file = tmp_path / "state.json"
+        monkeypatch.setattr(orchestrator, "STATE_FILE", state_file)
+
+        orchestrator.save_state({"onboarded": ["AAPL"], "last_run": "2024-01-01"})
+        orchestrator.save_state({"onboarded": ["AAPL", "MSFT"], "last_run": "2024-01-02"})
+
+        loaded = orchestrator.load_state()
+        assert loaded["onboarded"] == ["AAPL", "MSFT"]
+        assert loaded["last_run"] == "2024-01-02"
+
+    def test_date_objects_serialised_as_strings(self, tmp_path, monkeypatch):
+        """save_state uses default=str so date objects don't raise TypeError."""
+        state_file = tmp_path / "state.json"
+        monkeypatch.setattr(orchestrator, "STATE_FILE", state_file)
+
+        # Should not raise even with a date value
+        orchestrator.save_state({"last_run": date(2024, 1, 15), "onboarded": []})
+        raw = json.loads(state_file.read_text())
+        assert raw["last_run"] == "2024-01-15"
+
+
+# ---------------------------------------------------------------------------
+# load_ordered_tickers()
+# ---------------------------------------------------------------------------
+
+
+class TestLoadOrderedTickers:
+    def test_raises_when_file_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(orchestrator, "TICKERS_FILE", tmp_path / "nonexistent.csv")
+        with pytest.raises(FileNotFoundError):
+            orchestrator.load_ordered_tickers()
+
+    def test_raises_when_symbol_column_absent(self, tmp_path, monkeypatch):
+        tickers_file = tmp_path / "tickers.csv"
+        monkeypatch.setattr(orchestrator, "TICKERS_FILE", tickers_file)
+        pd.DataFrame({"ticker": ["AAPL"]}).to_csv(tickers_file, index=False)
+
+        with pytest.raises(ValueError, match="symbol"):
+            orchestrator.load_ordered_tickers()
+
+    def test_returns_list_of_strings(self, tmp_path, monkeypatch):
+        tickers_file = tmp_path / "tickers.csv"
+        monkeypatch.setattr(orchestrator, "TICKERS_FILE", tickers_file)
+        pd.DataFrame(
+            {
+                "symbol": ["AAPL", "MSFT"],
+                "market_value": [3e12, 2.8e12],
+                "index": ["SP500", "SP500"],
+            }
+        ).to_csv(tickers_file, index=False)
+
+        result = orchestrator.load_ordered_tickers()
+        assert isinstance(result, list)
+        assert all(isinstance(s, str) for s in result)
+
+    def test_preserves_csv_row_order(self, tmp_path, monkeypatch):
+        """load_ordered_tickers returns symbols in the order they appear in the CSV."""
+        tickers_file = tmp_path / "tickers.csv"
+        monkeypatch.setattr(orchestrator, "TICKERS_FILE", tickers_file)
+
+        symbols = ["BIG", "MEDIUM", "SMALL"]
+        pd.DataFrame(
+            {
+                "symbol": symbols,
+                "market_value": [1_000_000.0, 500_000.0, 100_000.0],
+                "index": ["SP500"] * 3,
+                "date_added": ["2024-01-01"] * 3,
+            }
+        ).to_csv(tickers_file, index=False)
+
+        result = orchestrator.load_ordered_tickers()
+        assert result == symbols
+
+    def test_drops_nan_symbols(self, tmp_path, monkeypatch):
+        tickers_file = tmp_path / "tickers.csv"
+        monkeypatch.setattr(orchestrator, "TICKERS_FILE", tickers_file)
+
+        # Write a CSV where one symbol cell is blank
+        tickers_file.write_text("symbol,market_value\nAAPL,1000\n,500\nMSFT,900\n")
+        result = orchestrator.load_ordered_tickers()
+        assert "" not in result
+        assert "AAPL" in result
+        assert "MSFT" in result
+
+    def test_all_symbols_present(self, tmp_path, monkeypatch):
+        tickers_file = tmp_path / "tickers.csv"
+        monkeypatch.setattr(orchestrator, "TICKERS_FILE", tickers_file)
+
+        expected = ["AAPL", "MSFT", "GOOGL", "AMZN", "META"]
+        pd.DataFrame({"symbol": expected, "market_value": range(len(expected))}).to_csv(
+            tickers_file, index=False
+        )
+
+        result = orchestrator.load_ordered_tickers()
+        assert set(result) == set(expected)
+        assert len(result) == len(expected)

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -7,7 +7,6 @@ No network calls or pipeline steps are exercised here.
 
 import json
 from datetime import date
-from pathlib import Path
 
 import pandas as pd
 import pytest

--- a/tests/test_verify_onboarding.py
+++ b/tests/test_verify_onboarding.py
@@ -1,0 +1,203 @@
+"""
+Tests for verify_onboarding.py: check() and fix().
+
+Uses tmp_path so no real state.json or data/ directory is touched.
+Parquet files are only touched as placeholders (zero-byte touch is sufficient
+because check() only inspects filenames, not file contents).
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from market_data.verify_onboarding import check, fix
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_state(tmp_path: Path, onboarded: list[str]) -> Path:
+    state_file = tmp_path / "state.json"
+    state_file.write_text(json.dumps({"onboarded": onboarded}))
+    return state_file
+
+
+def _make_data_dir(tmp_path: Path, symbols: list[str]) -> Path:
+    data_dir = tmp_path / "ohlcv"
+    data_dir.mkdir(exist_ok=True)
+    for sym in symbols:
+        (data_dir / f"{sym}.parquet").touch()
+    return data_dir
+
+
+# ---------------------------------------------------------------------------
+# check()
+# ---------------------------------------------------------------------------
+
+
+class TestCheck:
+    def test_clean_state_no_ghosts_no_orphans(self, tmp_path):
+        state_file = _make_state(tmp_path, ["AAPL", "MSFT"])
+        data_dir = _make_data_dir(tmp_path, ["AAPL", "MSFT"])
+        ghosts, orphans = check(state_file, data_dir)
+
+        assert ghosts == []
+        assert orphans == []
+
+    def test_ghost_detected_when_file_missing(self, tmp_path):
+        """Ticker in state but no file on disk is a ghost."""
+        state_file = _make_state(tmp_path, ["AAPL", "GHOST"])
+        data_dir = _make_data_dir(tmp_path, ["AAPL"])
+
+        ghosts, orphans = check(state_file, data_dir)
+        assert "GHOST" in ghosts
+        assert "AAPL" not in ghosts
+
+    def test_orphan_detected_when_file_not_in_state(self, tmp_path):
+        """File on disk but absent from state is an orphan."""
+        state_file = _make_state(tmp_path, ["AAPL"])
+        data_dir = _make_data_dir(tmp_path, ["AAPL", "ORPHAN"])
+
+        ghosts, orphans = check(state_file, data_dir)
+        assert "ORPHAN" in orphans
+        assert "AAPL" not in orphans
+
+    def test_ghost_and_orphan_simultaneously(self, tmp_path):
+        state_file = _make_state(tmp_path, ["AAPL", "GHOST"])
+        data_dir = _make_data_dir(tmp_path, ["AAPL", "ORPHAN"])
+
+        ghosts, orphans = check(state_file, data_dir)
+        assert ghosts == ["GHOST"]
+        assert orphans == ["ORPHAN"]
+
+    def test_empty_onboarded_list(self, tmp_path):
+        """With no onboarded tickers, any file on disk is an orphan."""
+        state_file = _make_state(tmp_path, [])
+        data_dir = _make_data_dir(tmp_path, ["AAPL"])
+
+        ghosts, orphans = check(state_file, data_dir)
+        assert ghosts == []
+        assert "AAPL" in orphans
+
+    def test_empty_data_dir(self, tmp_path):
+        """With no files on disk, every onboarded ticker is a ghost."""
+        state_file = _make_state(tmp_path, ["AAPL", "MSFT"])
+        data_dir = tmp_path / "ohlcv"
+        data_dir.mkdir()
+
+        ghosts, orphans = check(state_file, data_dir)
+        assert set(ghosts) == {"AAPL", "MSFT"}
+        assert orphans == []
+
+    def test_both_lists_are_sorted(self, tmp_path):
+        """Ghosts and orphans are returned in sorted order."""
+        state_file = _make_state(tmp_path, ["ZZZZ", "AAPL", "GHOST_B", "GHOST_A"])
+        data_dir = _make_data_dir(tmp_path, ["AAPL", "ORPHAN_B", "ORPHAN_A"])
+
+        ghosts, orphans = check(state_file, data_dir)
+        assert ghosts == sorted(ghosts)
+        assert orphans == sorted(orphans)
+
+    def test_raises_when_state_file_missing(self, tmp_path):
+        data_dir = _make_data_dir(tmp_path, [])
+        with pytest.raises(FileNotFoundError):
+            check(tmp_path / "nonexistent.json", data_dir)
+
+    def test_multiple_ghosts(self, tmp_path):
+        state_file = _make_state(tmp_path, ["AAPL", "GHOST1", "GHOST2", "GHOST3"])
+        data_dir = _make_data_dir(tmp_path, ["AAPL"])
+
+        ghosts, _ = check(state_file, data_dir)
+        assert set(ghosts) == {"GHOST1", "GHOST2", "GHOST3"}
+
+    def test_multiple_orphans(self, tmp_path):
+        state_file = _make_state(tmp_path, ["AAPL"])
+        data_dir = _make_data_dir(tmp_path, ["AAPL", "ORP1", "ORP2", "ORP3"])
+
+        _, orphans = check(state_file, data_dir)
+        assert set(orphans) == {"ORP1", "ORP2", "ORP3"}
+
+    def test_large_onboarded_list(self, tmp_path):
+        """Correctness holds with many symbols."""
+        all_syms = [f"SYM{i:04d}" for i in range(200)]
+        ghost_syms = all_syms[:10]   # first 10 have no file
+        disk_syms = all_syms[10:]    # rest have a file
+
+        state_file = _make_state(tmp_path, all_syms)
+        data_dir = _make_data_dir(tmp_path, disk_syms)
+
+        ghosts, orphans = check(state_file, data_dir)
+        assert set(ghosts) == set(ghost_syms)
+        assert orphans == []
+
+
+# ---------------------------------------------------------------------------
+# fix()
+# ---------------------------------------------------------------------------
+
+
+class TestFix:
+    def test_removes_ghosts_from_state(self, tmp_path):
+        state_file = _make_state(tmp_path, ["AAPL", "GHOST1", "GHOST2"])
+        fix(state_file, ["GHOST1", "GHOST2"])
+
+        raw = json.loads(state_file.read_text())
+        assert "GHOST1" not in raw["onboarded"]
+        assert "GHOST2" not in raw["onboarded"]
+        assert "AAPL" in raw["onboarded"]
+
+    def test_returns_count_removed(self, tmp_path):
+        state_file = _make_state(tmp_path, ["AAPL", "MSFT", "GHOST"])
+        removed = fix(state_file, ["GHOST"])
+        assert removed == 1
+
+    def test_returns_zero_for_empty_ghosts_list(self, tmp_path):
+        state_file = _make_state(tmp_path, ["AAPL", "MSFT"])
+        removed = fix(state_file, [])
+        assert removed == 0
+
+    def test_state_file_updated_on_disk(self, tmp_path):
+        state_file = _make_state(tmp_path, ["AAPL", "GHOST"])
+        fix(state_file, ["GHOST"])
+
+        raw = json.loads(state_file.read_text())
+        assert raw["onboarded"] == ["AAPL"]
+
+    def test_onboarded_list_remains_sorted(self, tmp_path):
+        state_file = _make_state(tmp_path, ["AAPL", "GHOST", "MSFT", "TSLA"])
+        fix(state_file, ["GHOST"])
+
+        raw = json.loads(state_file.read_text())
+        onboarded = raw["onboarded"]
+        assert onboarded == sorted(onboarded)
+
+    def test_fix_is_idempotent(self, tmp_path):
+        """Calling fix twice with the same ghosts list has the same net effect."""
+        state_file = _make_state(tmp_path, ["AAPL", "GHOST"])
+        fix(state_file, ["GHOST"])
+        fix(state_file, ["GHOST"])  # second call is a no-op
+
+        raw = json.loads(state_file.read_text())
+        assert "GHOST" not in raw["onboarded"]
+        assert "AAPL" in raw["onboarded"]
+
+    def test_non_ghost_fields_preserved(self, tmp_path):
+        """fix() must not destroy other fields in state.json."""
+        state_file = tmp_path / "state.json"
+        state_file.write_text(
+            json.dumps(
+                {
+                    "onboarded": ["AAPL", "GHOST"],
+                    "last_run": "2024-01-15",
+                    "options_cycle": ["AAPL"],
+                }
+            )
+        )
+        fix(state_file, ["GHOST"])
+
+        raw = json.loads(state_file.read_text())
+        assert raw["last_run"] == "2024-01-15"
+        assert raw["options_cycle"] == ["AAPL"]


### PR DESCRIPTION
## Summary

- **92 tests** across 5 modules — no network calls, all run in `tmp_path`
- **GitHub Actions CI** with two independent jobs: `test` (Python 3.10 + 3.12 matrix) and `lint` (ruff)
- **pytest-cov** wired in via `pyproject.toml` so coverage prints on every run

## What's tested

| File | Covers |
|---|---|
| `tests/test_fetch.py` | `_normalize()` (MultiIndex, TZ-aware dates, missing volume, empty input), `save_ticker_data()` idempotency/dedup/append, `load_ticker_data()` round-trip |
| `tests/test_fetch_tickers.py` | `clean_holdings()` filtering (CVR/warrant/rights/escrow, non-equity asset class, dash tickers, ticker corrections, market-value parsing), `apply_date_added()` date preservation + new-ticker assignment + dropped-ticker carry-forward + backfill, `merge_holdings()` overlap strategy, `_inject_etf_rows()` idempotency |
| `tests/test_merge.py` | Multi-file merge, combined row count, dedup on `(date, symbol)`, sort order, self-exclusion of the merged output file, parent-dir creation |
| `tests/test_orchestrator.py` | `load_state()` / `save_state()` round-trip and defaults for missing keys, `load_ordered_tickers()` order, error cases, NaN symbol handling |
| `tests/test_verify_onboarding.py` | `check()` ghost/orphan detection, both lists sorted, large-list correctness; `fix()` ghost removal, idempotency, preservation of non-onboarded fields |

## Test plan

- [x] All 92 tests pass locally (`python -m pytest --tb=short`)
- [ ] CI passes on both Python 3.10 and 3.12
- [ ] Ruff lint passes on `src/` and `tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)