### PR TITLE
Fix TIP ticker in BROAD_ETFS (was TIPS)

### DIFF
--- a/src/market_data/etf_config.py
+++ b/src/market_data/etf_config.py
@@ -66,7 +66,7 @@ BROAD_ETFS: list[tuple[str, str]] = [
     ("SHY",  "iShares 1-3 Year Treasury Bond ETF"),
     ("IEF",  "iShares 7-10 Year Treasury Bond ETF"),
     ("TLT",  "iShares 20+ Year Treasury Bond ETF"),
-    ("TIPS", "iShares TIPS Bond ETF"),
+    ("TIP",  "iShares TIPS Bond ETF"),
     ("EMB",  "iShares JP Morgan USD Emerging Markets Bond ETF"),
     ("MUB",  "iShares National Muni Bond ETF"),
     # --- Commodities ---


### PR DESCRIPTION
## Summary
- The bonds section of `BROAD_ETFS` in `etf_config.py` had the ticker `TIPS` which is not a valid symbol — the correct iShares TIPS Bond ETF ticker is `TIP`.
- This fix ensures price collection, options chains, and incremental updates target the right instrument.

## Test plan
- [ ] Confirm `TIP` appears in the bonds section of `BROAD_ETFS`
- [ ] Run ticker refresh and verify `TIP` is ingested correctly