### PR TITLE
Add pipeline run metrics

### DIFF
--- a/src/market_data/metrics.py
+++ b/src/market_data/metrics.py
@@ -1,0 +1,170 @@
+"""
+metrics.py
+----------
+Tracks and persists pipeline run metrics to logs/metrics.json.
+
+Each pipeline run records:
+  data_type           Pipeline step label (onboard, update, options, fundamentals, macro)
+  start_time          ISO-8601 UTC timestamp when the run began
+  end_time            ISO-8601 UTC timestamp when the run finished
+  duration_seconds    Wall-clock seconds for the full run
+  symbols_attempted   Total symbols processed
+  symbols_succeeded   Symbols that produced data without error
+  symbols_failed      List of {"symbol": ..., "reason": ...} for every failure
+  rows_written        Dict of {data_type: row_count} for data written
+
+The file keeps a rolling 90-day window of run history; older entries are
+pruned automatically when finish_run() is called.
+
+Usage (from orchestrator)
+--------------------------
+    from market_data import metrics
+
+    metrics.start_run("onboard")
+    ...
+    metrics.record_symbol_result("AAPL", success=True, rows_written=2520)
+    metrics.record_symbol_result("BADTICKER", success=False, reason="no data")
+    ...
+    metrics.finish_run()
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+METRICS_FILE = Path("logs/metrics.json")
+RETENTION_DAYS = 90
+
+# Module-level state for the currently active run
+_current_run: dict | None = None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def start_run(data_type: str) -> None:
+    """Initialise metrics tracking for a new pipeline run."""
+    global _current_run
+    _current_run = {
+        "data_type": data_type,
+        "start_time": datetime.now(timezone.utc).isoformat(),
+        "end_time": None,
+        "duration_seconds": None,
+        "symbols_attempted": 0,
+        "symbols_succeeded": 0,
+        "symbols_failed": [],
+        "rows_written": {},
+    }
+    logger.debug("metrics: %s run started at %s", data_type, _current_run["start_time"])
+
+
+def record_symbol_result(
+    symbol: str,
+    success: bool,
+    rows_written: int = 0,
+    reason: str | None = None,
+) -> None:
+    """
+    Record the outcome for a single symbol.
+
+    Parameters
+    ----------
+    symbol       : Ticker or series ID
+    success      : True if data was fetched without error
+    rows_written : Net-new rows written (meaningful only when success=True)
+    reason       : Short description of why the symbol failed (when success=False)
+    """
+    if _current_run is None:
+        return
+
+    _current_run["symbols_attempted"] += 1
+
+    if success:
+        _current_run["symbols_succeeded"] += 1
+        data_type = _current_run["data_type"]
+        _current_run["rows_written"][data_type] = (
+            _current_run["rows_written"].get(data_type, 0) + rows_written
+        )
+    else:
+        failure_reason = reason or "unknown"
+        _current_run["symbols_failed"].append({"symbol": symbol, "reason": failure_reason})
+        logger.debug(
+            "metrics: %s/%s failed — %s", _current_run["data_type"], symbol, failure_reason
+        )
+
+
+def finish_run() -> None:
+    """
+    Finalise the current run, compute duration, persist to metrics.json, and
+    reset module state.
+    """
+    global _current_run
+    if _current_run is None:
+        return
+
+    end_time = datetime.now(timezone.utc)
+    start_time = datetime.fromisoformat(_current_run["start_time"])
+
+    _current_run["end_time"] = end_time.isoformat()
+    _current_run["duration_seconds"] = round(
+        (end_time - start_time).total_seconds(), 2
+    )
+
+    logger.debug(
+        "metrics: %s run finished — %.1fs, %d succeeded, %d failed",
+        _current_run["data_type"],
+        _current_run["duration_seconds"],
+        _current_run["symbols_succeeded"],
+        len(_current_run["symbols_failed"]),
+    )
+
+    try:
+        _persist(_current_run.copy())
+    except Exception:
+        logger.warning("metrics: failed to persist run metrics", exc_info=True)
+
+    _current_run = None
+
+
+def load_history() -> dict:
+    """Load the full metrics history from disk. Returns {"runs": []} if missing."""
+    if not METRICS_FILE.exists():
+        return {"runs": []}
+    try:
+        return json.loads(METRICS_FILE.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {"runs": []}
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _persist(run: dict) -> None:
+    """Append `run` to metrics.json and prune entries older than RETENTION_DAYS."""
+    METRICS_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+    if METRICS_FILE.exists():
+        try:
+            data = json.loads(METRICS_FILE.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            logger.warning("metrics: could not read existing metrics.json; starting fresh")
+            data = {"runs": []}
+    else:
+        data = {"runs": []}
+
+    data["runs"].append(run)
+
+    # Prune runs older than RETENTION_DAYS
+    cutoff = (
+        datetime.now(timezone.utc) - timedelta(days=RETENTION_DAYS)
+    ).isoformat()
+    data["runs"] = [r for r in data["runs"] if r.get("start_time", "") >= cutoff]
+
+    METRICS_FILE.write_text(json.dumps(data, indent=2), encoding="utf-8")

--- a/src/market_data/orchestrator.py
+++ b/src/market_data/orchestrator.py
@@ -52,6 +52,7 @@ from pathlib import Path
 import pandas as pd
 
 from market_data.fetch import DEFAULT_HISTORY_YEARS, fetch_history, fetch_incremental, save_ticker_data
+from market_data import metrics
 
 logger = logging.getLogger(__name__)
 
@@ -175,10 +176,15 @@ def maybe_run_fundamentals(
     )
     try:
         from market_data import fetch_fundamentals  # noqa: PLC0415
+        metrics.start_run("fundamentals")
         fetch_fundamentals.run(symbols=symbols)
+        for s in symbols:
+            metrics.record_symbol_result(s, success=True)
+        metrics.finish_run()
         return True
     except Exception as exc:
         logger.warning("Fundamentals fetch failed: %s.", exc, exc_info=True)
+        metrics.finish_run()
         return False
 
 
@@ -232,20 +238,23 @@ def step_options(
         remaining_after,
     )
 
+    metrics.start_run("options")
     fetch_options.run(symbols=batch, max_expiries=max_expiries)
 
     # Silent failure detection: warn if all symbols produced no options data
     if batch:
         from market_data.fetch_options import OPTIONS_DIR  # noqa: PLC0415
-        options_written = sum(
-            1 for s in batch
-            if (OPTIONS_DIR / f"{s}.parquet").exists()
-        )
+        for s in batch:
+            wrote = (OPTIONS_DIR / f"{s}.parquet").exists()
+            metrics.record_symbol_result(s, success=wrote, reason="no options file written" if not wrote else None)
+        options_written = sum(1 for s in batch if (OPTIONS_DIR / f"{s}.parquet").exists())
         if options_written == 0:
             logger.warning(
                 "OPTIONS silent failure: processed %d symbol(s) but no options files exist",
                 len(batch),
             )
+
+    metrics.finish_run()
 
     updated_cycle = cycle_done | set(batch)
     if remaining_after == 0:
@@ -305,21 +314,27 @@ def step_onboard(
         len(pending) - len(to_onboard),
     )
 
+    metrics.start_run("onboard")
     for i, symbol in enumerate(to_onboard, 1):
         prefix = f"[{i:>3}/{len(to_onboard)}] {symbol:<8}"
         try:
             df = fetch_history(symbol, years=DEFAULT_HISTORY_YEARS)
             if df.empty:
                 logger.info("%s  no data (skipping)", prefix)
+                metrics.record_symbol_result(symbol, success=False, reason="no data")
             else:
                 added = save_ticker_data(symbol, df, DATA_DIR)
                 newly_onboarded.add(symbol)
                 logger.info("%s  %d rows saved", prefix, added)
+                metrics.record_symbol_result(symbol, success=True, rows_written=added)
         except Exception as exc:
             logger.error("%s  ERROR: %s", prefix, exc, exc_info=True)
             failed.add(symbol)
+            metrics.record_symbol_result(symbol, success=False, reason=str(exc))
 
         time.sleep(SLEEP_BETWEEN_CALLS)
+
+    metrics.finish_run()
 
     # Silent failure detection
     if to_onboard and not newly_onboarded:
@@ -347,6 +362,7 @@ def step_update(
 
     logger.info("UPDATE   %d tickers  (since %s)", len(to_update), since)
 
+    metrics.start_run("update")
     total_rows = 0
     for i, symbol in enumerate(to_update, 1):
         prefix = f"[{i:>4}/{len(to_update)}] {symbol:<8}"
@@ -355,16 +371,21 @@ def step_update(
             if df.empty:
                 logger.info("%s  up to date", prefix)
                 results[symbol] = 0
+                metrics.record_symbol_result(symbol, success=True, rows_written=0)
             else:
                 added = save_ticker_data(symbol, df, DATA_DIR)
                 logger.info("%s  +%d rows", prefix, added)
                 results[symbol] = added
                 total_rows += added
+                metrics.record_symbol_result(symbol, success=True, rows_written=added)
         except Exception as exc:
             logger.error("%s  ERROR: %s", prefix, exc, exc_info=True)
             results[symbol] = 0
+            metrics.record_symbol_result(symbol, success=False, reason=str(exc))
 
         time.sleep(SLEEP_BETWEEN_CALLS)
+
+    metrics.finish_run()
 
     # Silent failure detection: if last_run was recent but all symbols returned 0
     # rows AND the batch is large enough that some data was expected, warn.
@@ -456,12 +477,16 @@ def run(batch_size: int, skip_update: bool, run_merge: bool, run_indices: bool =
     # --- 5. Optional indices update ---
     if run_indices:
         from market_data import fetch_indices  # noqa: PLC0415
+        metrics.start_run("indices")
         fetch_indices.run()
+        metrics.finish_run()
 
     # --- 6. Optional macro update ---
     if run_macro:
         from market_data import fetch_macro  # noqa: PLC0415
+        metrics.start_run("macro")
         fetch_macro.run()
+        metrics.finish_run()
 
     # --- 7. Persist state ---
     state["onboarded"] = sorted(onboarded)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,378 @@
+"""
+Tests for metrics.py: start_run(), record_symbol_result(), finish_run(),
+persistence to metrics.json, load_history(), and 90-day retention pruning.
+"""
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+import market_data.metrics as metrics_mod
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_run_entry(days_ago: int, data_type: str = "onboard") -> dict:
+    """Return a fake run dict with start_time `days_ago` days in the past."""
+    ts = (datetime.now(timezone.utc) - timedelta(days=days_ago)).isoformat()
+    return {
+        "data_type": data_type,
+        "start_time": ts,
+        "end_time": ts,
+        "duration_seconds": 1.0,
+        "symbols_attempted": 0,
+        "symbols_succeeded": 0,
+        "symbols_failed": [],
+        "rows_written": {},
+    }
+
+
+# ---------------------------------------------------------------------------
+# start_run / finish_run lifecycle
+# ---------------------------------------------------------------------------
+
+class TestRunLifecycle:
+    def setup_method(self):
+        """Reset module state before each test."""
+        metrics_mod._current_run = None
+
+    def test_start_run_initialises_state(self):
+        metrics_mod.start_run("onboard")
+        assert metrics_mod._current_run is not None
+        assert metrics_mod._current_run["data_type"] == "onboard"
+        assert metrics_mod._current_run["symbols_attempted"] == 0
+        assert metrics_mod._current_run["symbols_succeeded"] == 0
+        assert metrics_mod._current_run["symbols_failed"] == []
+        assert metrics_mod._current_run["rows_written"] == {}
+        assert metrics_mod._current_run["end_time"] is None
+
+    def test_start_run_sets_iso_start_time(self):
+        metrics_mod.start_run("update")
+        ts = metrics_mod._current_run["start_time"]
+        parsed = datetime.fromisoformat(ts)
+        assert parsed is not None
+
+    def test_finish_run_clears_state(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(metrics_mod, "METRICS_FILE", tmp_path / "metrics.json")
+        metrics_mod.start_run("onboard")
+        metrics_mod.finish_run()
+        assert metrics_mod._current_run is None
+
+    def test_finish_run_without_start_is_noop(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(metrics_mod, "METRICS_FILE", tmp_path / "metrics.json")
+        metrics_mod._current_run = None
+        metrics_mod.finish_run()  # should not raise
+        assert not (tmp_path / "metrics.json").exists()
+
+    def test_finish_run_computes_duration(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(metrics_mod, "METRICS_FILE", tmp_path / "metrics.json")
+        metrics_mod.start_run("onboard")
+        metrics_mod.finish_run()
+
+        data = json.loads((tmp_path / "metrics.json").read_text())
+        run = data["runs"][0]
+        assert run["duration_seconds"] >= 0
+        assert run["end_time"] is not None
+
+    def test_finish_run_writes_data_type(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(metrics_mod, "METRICS_FILE", tmp_path / "metrics.json")
+        metrics_mod.start_run("fundamentals")
+        metrics_mod.finish_run()
+
+        data = json.loads((tmp_path / "metrics.json").read_text())
+        assert data["runs"][0]["data_type"] == "fundamentals"
+
+
+# ---------------------------------------------------------------------------
+# record_symbol_result
+# ---------------------------------------------------------------------------
+
+class TestRecordSymbolResult:
+    def setup_method(self):
+        metrics_mod._current_run = None
+
+    def test_record_success_increments_counts(self):
+        metrics_mod.start_run("onboard")
+        metrics_mod.record_symbol_result("AAPL", success=True, rows_written=100)
+
+        assert metrics_mod._current_run["symbols_attempted"] == 1
+        assert metrics_mod._current_run["symbols_succeeded"] == 1
+        assert metrics_mod._current_run["rows_written"]["onboard"] == 100
+
+    def test_record_failure_adds_to_failed_list(self):
+        metrics_mod.start_run("onboard")
+        metrics_mod.record_symbol_result("BADTICKER", success=False, reason="no data")
+
+        assert metrics_mod._current_run["symbols_attempted"] == 1
+        assert metrics_mod._current_run["symbols_succeeded"] == 0
+        failed = metrics_mod._current_run["symbols_failed"]
+        assert len(failed) == 1
+        assert failed[0]["symbol"] == "BADTICKER"
+        assert failed[0]["reason"] == "no data"
+
+    def test_record_failure_without_reason_uses_unknown(self):
+        metrics_mod.start_run("onboard")
+        metrics_mod.record_symbol_result("X", success=False)
+        assert metrics_mod._current_run["symbols_failed"][0]["reason"] == "unknown"
+
+    def test_rows_written_accumulates_across_symbols(self):
+        metrics_mod.start_run("onboard")
+        metrics_mod.record_symbol_result("AAPL", success=True, rows_written=100)
+        metrics_mod.record_symbol_result("MSFT", success=True, rows_written=200)
+
+        assert metrics_mod._current_run["rows_written"]["onboard"] == 300
+
+    def test_rows_written_uses_run_data_type(self):
+        metrics_mod.start_run("options")
+        metrics_mod.record_symbol_result("AAPL", success=True, rows_written=500)
+
+        assert "options" in metrics_mod._current_run["rows_written"]
+        assert metrics_mod._current_run["rows_written"]["options"] == 500
+
+    def test_multiple_failures_accumulate(self):
+        metrics_mod.start_run("onboard")
+        metrics_mod.record_symbol_result("A", success=False, reason="err1")
+        metrics_mod.record_symbol_result("B", success=False, reason="err2")
+
+        failed = metrics_mod._current_run["symbols_failed"]
+        assert len(failed) == 2
+        symbols = {f["symbol"] for f in failed}
+        assert symbols == {"A", "B"}
+
+    def test_record_without_active_run_is_noop(self):
+        metrics_mod._current_run = None
+        # Should not raise
+        metrics_mod.record_symbol_result("AAPL", success=True, rows_written=100)
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+class TestPersistence:
+    def setup_method(self):
+        metrics_mod._current_run = None
+
+    def test_finish_run_creates_metrics_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(metrics_mod, "METRICS_FILE", tmp_path / "metrics.json")
+        metrics_mod.start_run("onboard")
+        metrics_mod.finish_run()
+        assert (tmp_path / "metrics.json").exists()
+
+    def test_metrics_file_is_valid_json(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(metrics_mod, "METRICS_FILE", tmp_path / "metrics.json")
+        metrics_mod.start_run("onboard")
+        metrics_mod.finish_run()
+        data = json.loads((tmp_path / "metrics.json").read_text())
+        assert "runs" in data
+        assert isinstance(data["runs"], list)
+
+    def test_run_data_persisted_correctly(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(metrics_mod, "METRICS_FILE", tmp_path / "metrics.json")
+        metrics_mod.start_run("onboard")
+        metrics_mod.record_symbol_result("AAPL", success=True, rows_written=250)
+        metrics_mod.record_symbol_result("BAD", success=False, reason="err")
+        metrics_mod.finish_run()
+
+        data = json.loads((tmp_path / "metrics.json").read_text())
+        run = data["runs"][0]
+        assert run["symbols_attempted"] == 2
+        assert run["symbols_succeeded"] == 1
+        assert run["symbols_failed"] == [{"symbol": "BAD", "reason": "err"}]
+        assert run["rows_written"]["onboard"] == 250
+
+    def test_multiple_runs_accumulate(self, tmp_path, monkeypatch):
+        metrics_file = tmp_path / "metrics.json"
+        monkeypatch.setattr(metrics_mod, "METRICS_FILE", metrics_file)
+
+        for _ in range(3):
+            metrics_mod.start_run("update")
+            metrics_mod.finish_run()
+
+        data = json.loads(metrics_file.read_text())
+        assert len(data["runs"]) == 3
+
+    def test_creates_logs_subdirectory(self, tmp_path, monkeypatch):
+        metrics_file = tmp_path / "logs" / "metrics.json"
+        monkeypatch.setattr(metrics_mod, "METRICS_FILE", metrics_file)
+        metrics_mod.start_run("onboard")
+        metrics_mod.finish_run()
+        assert metrics_file.exists()
+
+    def test_corrupt_existing_file_starts_fresh(self, tmp_path, monkeypatch):
+        metrics_file = tmp_path / "metrics.json"
+        monkeypatch.setattr(metrics_mod, "METRICS_FILE", metrics_file)
+        metrics_file.write_text("not valid json {{{{")
+
+        metrics_mod.start_run("onboard")
+        metrics_mod.finish_run()
+
+        data = json.loads(metrics_file.read_text())
+        assert len(data["runs"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# 90-day retention pruning
+# ---------------------------------------------------------------------------
+
+class TestRetentionPruning:
+    def setup_method(self):
+        metrics_mod._current_run = None
+
+    def test_old_runs_are_pruned(self, tmp_path, monkeypatch):
+        metrics_file = tmp_path / "metrics.json"
+        monkeypatch.setattr(metrics_mod, "METRICS_FILE", metrics_file)
+        monkeypatch.setattr(metrics_mod, "RETENTION_DAYS", 90)
+
+        old_run = _make_run_entry(days_ago=100)
+        metrics_file.write_text(json.dumps({"runs": [old_run]}))
+
+        metrics_mod.start_run("onboard")
+        metrics_mod.finish_run()
+
+        data = json.loads(metrics_file.read_text())
+        assert len(data["runs"]) == 1
+        assert data["runs"][0]["duration_seconds"] >= 0
+
+    def test_recent_runs_are_kept(self, tmp_path, monkeypatch):
+        metrics_file = tmp_path / "metrics.json"
+        monkeypatch.setattr(metrics_mod, "METRICS_FILE", metrics_file)
+        monkeypatch.setattr(metrics_mod, "RETENTION_DAYS", 90)
+
+        runs = [_make_run_entry(days_ago=10), _make_run_entry(days_ago=50)]
+        metrics_file.write_text(json.dumps({"runs": runs}))
+
+        metrics_mod.start_run("onboard")
+        metrics_mod.finish_run()
+
+        data = json.loads(metrics_file.read_text())
+        assert len(data["runs"]) == 3
+
+    def test_exactly_at_boundary_is_kept(self, tmp_path, monkeypatch):
+        metrics_file = tmp_path / "metrics.json"
+        monkeypatch.setattr(metrics_mod, "METRICS_FILE", metrics_file)
+        monkeypatch.setattr(metrics_mod, "RETENTION_DAYS", 90)
+
+        # A run exactly 89 days ago should survive
+        runs = [_make_run_entry(days_ago=89)]
+        metrics_file.write_text(json.dumps({"runs": runs}))
+
+        metrics_mod.start_run("onboard")
+        metrics_mod.finish_run()
+
+        data = json.loads(metrics_file.read_text())
+        assert len(data["runs"]) == 2
+
+    def test_custom_retention_days(self, tmp_path, monkeypatch):
+        metrics_file = tmp_path / "metrics.json"
+        monkeypatch.setattr(metrics_mod, "METRICS_FILE", metrics_file)
+        monkeypatch.setattr(metrics_mod, "RETENTION_DAYS", 7)
+
+        old = _make_run_entry(days_ago=10)
+        recent = _make_run_entry(days_ago=3)
+        metrics_file.write_text(json.dumps({"runs": [old, recent]}))
+
+        metrics_mod.start_run("onboard")
+        metrics_mod.finish_run()
+
+        data = json.loads(metrics_file.read_text())
+        # old run pruned, recent + new run survive
+        assert len(data["runs"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# load_history
+# ---------------------------------------------------------------------------
+
+class TestLoadHistory:
+    def setup_method(self):
+        metrics_mod._current_run = None
+
+    def test_returns_empty_when_file_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(metrics_mod, "METRICS_FILE", tmp_path / "metrics.json")
+        result = metrics_mod.load_history()
+        assert result == {"runs": []}
+
+    def test_loads_existing_file(self, tmp_path, monkeypatch):
+        metrics_file = tmp_path / "metrics.json"
+        monkeypatch.setattr(metrics_mod, "METRICS_FILE", metrics_file)
+        metrics_file.write_text(json.dumps({"runs": [{"start_time": "2024-01-01"}]}))
+        result = metrics_mod.load_history()
+        assert len(result["runs"]) == 1
+
+    def test_returns_empty_on_corrupt_file(self, tmp_path, monkeypatch):
+        metrics_file = tmp_path / "metrics.json"
+        monkeypatch.setattr(metrics_mod, "METRICS_FILE", metrics_file)
+        metrics_file.write_text("not valid json {{{{")
+        result = metrics_mod.load_history()
+        assert result == {"runs": []}
+
+    def test_load_history_reflects_completed_runs(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(metrics_mod, "METRICS_FILE", tmp_path / "metrics.json")
+        metrics_mod.start_run("macro")
+        metrics_mod.finish_run()
+
+        history = metrics_mod.load_history()
+        assert len(history["runs"]) == 1
+        assert history["runs"][0]["data_type"] == "macro"
+        assert "start_time" in history["runs"][0]
+        assert "end_time" in history["runs"][0]
+        assert "duration_seconds" in history["runs"][0]
+
+
+# ---------------------------------------------------------------------------
+# File isolation (concurrent runs don't corrupt)
+# ---------------------------------------------------------------------------
+
+class TestFileIsolation:
+    def setup_method(self):
+        metrics_mod._current_run = None
+
+    def test_interleaved_writes_use_separate_paths(self, tmp_path, monkeypatch):
+        """Two separate METRICS_FILE paths never cross-contaminate."""
+        file_a = tmp_path / "a" / "metrics.json"
+        file_b = tmp_path / "b" / "metrics.json"
+        file_a.parent.mkdir()
+        file_b.parent.mkdir()
+
+        # Write to file A
+        monkeypatch.setattr(metrics_mod, "METRICS_FILE", file_a)
+        metrics_mod.start_run("onboard")
+        metrics_mod.record_symbol_result("AAPL", success=True, rows_written=100)
+        metrics_mod.finish_run()
+
+        # Write to file B
+        monkeypatch.setattr(metrics_mod, "METRICS_FILE", file_b)
+        metrics_mod.start_run("update")
+        metrics_mod.record_symbol_result("MSFT", success=True, rows_written=50)
+        metrics_mod.finish_run()
+
+        data_a = json.loads(file_a.read_text())
+        data_b = json.loads(file_b.read_text())
+
+        assert len(data_a["runs"]) == 1
+        assert data_a["runs"][0]["data_type"] == "onboard"
+        assert len(data_b["runs"]) == 1
+        assert data_b["runs"][0]["data_type"] == "update"
+
+    def test_second_run_appends_not_overwrites(self, tmp_path, monkeypatch):
+        """Each finish_run appends to the existing file rather than replacing it."""
+        metrics_file = tmp_path / "metrics.json"
+        monkeypatch.setattr(metrics_mod, "METRICS_FILE", metrics_file)
+
+        metrics_mod.start_run("onboard")
+        metrics_mod.record_symbol_result("AAPL", success=True, rows_written=100)
+        metrics_mod.finish_run()
+
+        metrics_mod.start_run("update")
+        metrics_mod.record_symbol_result("AAPL", success=True, rows_written=5)
+        metrics_mod.finish_run()
+
+        data = json.loads(metrics_file.read_text())
+        assert len(data["runs"]) == 2
+        assert data["runs"][0]["data_type"] == "onboard"
+        assert data["runs"][1]["data_type"] == "update"

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -5,9 +5,6 @@ persistence to metrics.json, load_history(), and 90-day retention pruning.
 
 import json
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
-
-import pytest
 
 import market_data.metrics as metrics_mod
 


### PR DESCRIPTION
## Summary

- Adds `market_data/metrics.py` with `start_run(data_type)`, `record_symbol_result(symbol, success, rows_written, reason)`, `finish_run()`, and `load_history()`
- Persists per-run data to `logs/metrics.json` with a 90-day rolling window (auto-pruned on `finish_run`)
- Wires metrics into all orchestrator pipeline steps: onboard, update, options, fundamentals, indices, macro
- 29 tests covering the full lifecycle, accumulation, pruning, persistence, corrupt-file recovery, and file isolation — all using `tmp_path`, never writing to real `logs/`

Closes #32

## Test plan

- [x] `pytest tests/test_metrics.py` — 29 passed
- [x] Full suite `pytest` — 121 passed, 0 failures