### PR TITLE
Add health check and staleness detection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ market-data-fetch-indices       = "market_data.fetch_indices:main"
 market-data-fetch-macro         = "market_data.fetch_macro:main"
 market-data-fetch-fundamentals  = "market_data.fetch_fundamentals:main"
 market-data-fetch-options       = "market_data.fetch_options:main"
+market-data-health              = "market_data.health:main"
 
 [project.optional-dependencies]
 dev = [

--- a/src/market_data/health.py
+++ b/src/market_data/health.py
@@ -1,0 +1,179 @@
+"""
+health.py
+---------
+Health-check utilities for the market_data pipeline.
+
+health_check() scans each data directory and verifies that its most recently
+modified Parquet file is within the expected update-frequency window.  Stale
+or missing data types are logged as warnings; fresh ones at INFO level.
+
+Expected freshness windows
+--------------------------
+  ohlcv          2 days  (daily equity prices)
+  options        14 days (options cycle covers ~500 tickers over ~10 days)
+  fundamentals   35 days (monthly snapshot run)
+  macro           7 days (FRED data; some series are monthly)
+
+Usage
+-----
+    from market_data.health import health_check
+    results = health_check()   # returns dict[str, dict]
+
+    # Or run as a standalone CLI check:
+    market-data-health
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Subdirectory names under the data root, keyed by data-type label
+_SUBDIR_NAMES: dict[str, str] = {
+    "ohlcv": "ohlcv",
+    "options": "options",
+    "fundamentals": "fundamentals",
+    "macro": "macro",
+}
+
+# Maximum acceptable age (days) for the most recently modified file
+FRESHNESS_WINDOWS: dict[str, int] = {
+    "ohlcv": 2,
+    "options": 14,
+    "fundamentals": 35,
+    "macro": 7,
+}
+
+_DEFAULT_DATA_DIR = Path("data")
+
+
+def health_check(data_dir: Path | None = None) -> dict[str, dict]:
+    """
+    Check whether each data type has been updated within its freshness window.
+
+    Uses the most recent file-modification timestamp among all *.parquet files
+    in each subdirectory as a proxy for "last updated".
+
+    Parameters
+    ----------
+    data_dir : Root directory containing ohlcv/, options/, fundamentals/, macro/
+               subdirectories.  Defaults to ``data/`` relative to cwd.
+
+    Returns
+    -------
+    dict mapping data_type → report dict with keys:
+      last_updated         datetime (UTC) of the most recent parquet file,
+                           or None if no files were found
+      expected_within_days int freshness threshold for this data type
+      is_stale             bool — True when missing or age exceeds threshold
+      age_days             float age in days, or None if no files were found
+    """
+    root = data_dir if data_dir is not None else _DEFAULT_DATA_DIR
+
+    now = datetime.now(timezone.utc)
+    results: dict[str, dict] = {}
+
+    for data_type, subdir_name in _SUBDIR_NAMES.items():
+        threshold_days = FRESHNESS_WINDOWS[data_type]
+        data_subdir = root / subdir_name
+
+        if not data_subdir.exists():
+            results[data_type] = {
+                "last_updated": None,
+                "expected_within_days": threshold_days,
+                "is_stale": True,
+                "age_days": None,
+            }
+            logger.warning(
+                "health_check: %s — directory not found (%s)", data_type, data_subdir
+            )
+            continue
+
+        parquet_files = list(data_subdir.glob("*.parquet"))
+        if not parquet_files:
+            results[data_type] = {
+                "last_updated": None,
+                "expected_within_days": threshold_days,
+                "is_stale": True,
+                "age_days": None,
+            }
+            logger.warning(
+                "health_check: %s — no parquet files in %s", data_type, data_subdir
+            )
+            continue
+
+        most_recent_mtime = max(p.stat().st_mtime for p in parquet_files)
+        last_updated = datetime.fromtimestamp(most_recent_mtime, tz=timezone.utc)
+        age_days = (now - last_updated).total_seconds() / 86400.0
+        is_stale = age_days > threshold_days
+
+        results[data_type] = {
+            "last_updated": last_updated,
+            "expected_within_days": threshold_days,
+            "is_stale": is_stale,
+            "age_days": age_days,
+        }
+
+        if is_stale:
+            logger.warning(
+                "health_check: %s — stale (%.1fd old, threshold %dd)",
+                data_type,
+                age_days,
+                threshold_days,
+            )
+        else:
+            logger.info(
+                "health_check: %s — ok (%.1fd old, threshold %dd)",
+                data_type,
+                age_days,
+                threshold_days,
+            )
+
+    stale_types = [k for k, v in results.items() if v["is_stale"]]
+    if stale_types:
+        logger.warning(
+            "health_check summary: %d stale/missing data type(s): %s",
+            len(stale_types),
+            stale_types,
+        )
+    else:
+        logger.info("health_check summary: all %d data types are fresh", len(results))
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Standalone CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    from market_data.logging_config import setup_logging  # noqa: PLC0415
+
+    setup_logging()
+
+    parser = argparse.ArgumentParser(
+        description="Check freshness of market_data pipeline outputs."
+    )
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=None,
+        metavar="DIR",
+        help="Root data directory containing ohlcv/, options/, etc. (default: data/)",
+    )
+    args = parser.parse_args()
+
+    results = health_check(data_dir=args.data_dir)
+
+    stale = [k for k, v in results.items() if v["is_stale"]]
+    if stale:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,234 @@
+"""
+Tests for health.py — health_check() freshness/staleness detection.
+
+All tests use tmp_path and never touch the real data/ directory.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+
+from market_data.health import health_check
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_parquet(path: Path, age_days: float = 0.0) -> None:
+    """Write a minimal parquet file and backdate its mtime by age_days."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame({"x": [1]}).to_parquet(path, index=False)
+
+    if age_days != 0.0:
+        offset_seconds = age_days * 86400.0
+        stat = path.stat()
+        new_mtime = stat.st_mtime - offset_seconds
+        os.utime(path, (new_mtime, new_mtime))
+
+
+def _single_type_dir(tmp_path: Path, data_type: str, age_days: float) -> Path:
+    """Create a data dir with one parquet file at the given age and return the root."""
+    root = tmp_path / "data"
+    _write_parquet(root / data_type / "TEST.parquet", age_days=age_days)
+    return root
+
+
+# ---------------------------------------------------------------------------
+# Report structure
+# ---------------------------------------------------------------------------
+
+class TestReportStructure:
+    EXPECTED_KEYS = {"last_updated", "expected_within_days", "is_stale", "age_days"}
+
+    def test_all_four_data_types_present(self, tmp_path):
+        root = tmp_path / "data"
+        result = health_check(data_dir=root)
+        assert set(result.keys()) == {"ohlcv", "options", "fundamentals", "macro"}
+
+    def test_each_entry_has_required_keys(self, tmp_path):
+        root = tmp_path / "data"
+        result = health_check(data_dir=root)
+        for data_type, report in result.items():
+            assert self.EXPECTED_KEYS == set(report.keys()), (
+                f"{data_type} missing keys: {self.EXPECTED_KEYS - set(report.keys())}"
+            )
+
+    def test_fresh_entry_types(self, tmp_path):
+        root = _single_type_dir(tmp_path, "ohlcv", age_days=0.5)
+        result = health_check(data_dir=root)
+        r = result["ohlcv"]
+        assert isinstance(r["last_updated"], datetime)
+        assert r["last_updated"].tzinfo is not None  # timezone-aware
+        assert isinstance(r["expected_within_days"], int)
+        assert isinstance(r["is_stale"], bool)
+        assert isinstance(r["age_days"], float)
+
+    def test_missing_entry_types(self, tmp_path):
+        root = tmp_path / "data"  # no subdirs created
+        result = health_check(data_dir=root)
+        r = result["ohlcv"]
+        assert r["last_updated"] is None
+        assert r["age_days"] is None
+        assert r["is_stale"] is True
+
+
+# ---------------------------------------------------------------------------
+# Missing directory / no parquet files
+# ---------------------------------------------------------------------------
+
+class TestMissingData:
+    def test_missing_directory_is_stale(self, tmp_path):
+        root = tmp_path / "data"  # ohlcv subdir never created
+        result = health_check(data_dir=root)
+        assert result["ohlcv"]["is_stale"] is True
+
+    def test_missing_directory_logs_warning(self, tmp_path, caplog):
+        root = tmp_path / "data"
+        with caplog.at_level(logging.WARNING, logger="market_data.health"):
+            health_check(data_dir=root)
+        assert any("not found" in r.message or "missing" in r.message.lower()
+                   for r in caplog.records)
+
+    def test_empty_directory_is_stale(self, tmp_path):
+        root = tmp_path / "data"
+        (root / "ohlcv").mkdir(parents=True)  # dir exists but no parquet files
+        result = health_check(data_dir=root)
+        assert result["ohlcv"]["is_stale"] is True
+
+    def test_missing_all_four_dirs(self, tmp_path):
+        root = tmp_path / "data"
+        result = health_check(data_dir=root)
+        for dt in ("ohlcv", "options", "fundamentals", "macro"):
+            assert result[dt]["is_stale"] is True
+
+
+# ---------------------------------------------------------------------------
+# Fresh data
+# ---------------------------------------------------------------------------
+
+class TestFreshData:
+    def test_ohlcv_fresh_within_2_days(self, tmp_path):
+        root = _single_type_dir(tmp_path, "ohlcv", age_days=1.0)
+        result = health_check(data_dir=root)
+        assert result["ohlcv"]["is_stale"] is False
+
+    def test_options_fresh_within_14_days(self, tmp_path):
+        root = _single_type_dir(tmp_path, "options", age_days=10.0)
+        result = health_check(data_dir=root)
+        assert result["options"]["is_stale"] is False
+
+    def test_fundamentals_fresh_within_35_days(self, tmp_path):
+        root = _single_type_dir(tmp_path, "fundamentals", age_days=30.0)
+        result = health_check(data_dir=root)
+        assert result["fundamentals"]["is_stale"] is False
+
+    def test_macro_fresh_within_7_days(self, tmp_path):
+        root = _single_type_dir(tmp_path, "macro", age_days=5.0)
+        result = health_check(data_dir=root)
+        assert result["macro"]["is_stale"] is False
+
+    def test_fresh_expected_within_days_correct(self, tmp_path):
+        root = _single_type_dir(tmp_path, "ohlcv", age_days=0.5)
+        result = health_check(data_dir=root)
+        assert result["ohlcv"]["expected_within_days"] == 2
+
+    def test_fresh_age_days_is_reasonable(self, tmp_path):
+        root = _single_type_dir(tmp_path, "ohlcv", age_days=1.0)
+        result = health_check(data_dir=root)
+        assert 0.9 < result["ohlcv"]["age_days"] < 1.1
+
+    def test_fresh_data_logs_info(self, tmp_path, caplog):
+        root = _single_type_dir(tmp_path, "ohlcv", age_days=0.5)
+        with caplog.at_level(logging.INFO, logger="market_data.health"):
+            health_check(data_dir=root)
+        assert any("ok" in r.message.lower() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Stale data
+# ---------------------------------------------------------------------------
+
+class TestStaleData:
+    def test_ohlcv_stale_beyond_2_days(self, tmp_path):
+        root = _single_type_dir(tmp_path, "ohlcv", age_days=3.0)
+        result = health_check(data_dir=root)
+        assert result["ohlcv"]["is_stale"] is True
+
+    def test_options_stale_beyond_14_days(self, tmp_path):
+        root = _single_type_dir(tmp_path, "options", age_days=20.0)
+        result = health_check(data_dir=root)
+        assert result["options"]["is_stale"] is True
+
+    def test_fundamentals_stale_beyond_35_days(self, tmp_path):
+        root = _single_type_dir(tmp_path, "fundamentals", age_days=40.0)
+        result = health_check(data_dir=root)
+        assert result["fundamentals"]["is_stale"] is True
+
+    def test_macro_stale_beyond_7_days(self, tmp_path):
+        root = _single_type_dir(tmp_path, "macro", age_days=10.0)
+        result = health_check(data_dir=root)
+        assert result["macro"]["is_stale"] is True
+
+    def test_stale_age_days_is_reasonable(self, tmp_path):
+        root = _single_type_dir(tmp_path, "ohlcv", age_days=5.0)
+        result = health_check(data_dir=root)
+        assert 4.9 < result["ohlcv"]["age_days"] < 5.1
+
+    def test_stale_expected_within_days_correct(self, tmp_path):
+        root = _single_type_dir(tmp_path, "macro", age_days=10.0)
+        result = health_check(data_dir=root)
+        assert result["macro"]["expected_within_days"] == 7
+
+    def test_stale_last_updated_is_datetime(self, tmp_path):
+        root = _single_type_dir(tmp_path, "ohlcv", age_days=5.0)
+        result = health_check(data_dir=root)
+        assert isinstance(result["ohlcv"]["last_updated"], datetime)
+
+    def test_stale_data_logs_warning(self, tmp_path, caplog):
+        root = _single_type_dir(tmp_path, "ohlcv", age_days=5.0)
+        with caplog.at_level(logging.WARNING, logger="market_data.health"):
+            health_check(data_dir=root)
+        assert any("stale" in r.message.lower() for r in caplog.records)
+
+    def test_most_recent_file_is_used(self, tmp_path):
+        """health_check picks the newest file, so one fresh file among old ones = ok."""
+        root = tmp_path / "data"
+        _write_parquet(root / "ohlcv" / "OLD.parquet", age_days=20.0)
+        _write_parquet(root / "ohlcv" / "NEW.parquet", age_days=0.5)
+        result = health_check(data_dir=root)
+        assert result["ohlcv"]["is_stale"] is False
+
+
+# ---------------------------------------------------------------------------
+# Summary logging
+# ---------------------------------------------------------------------------
+
+class TestSummaryLogging:
+    def test_summary_warning_when_any_stale(self, tmp_path, caplog):
+        root = tmp_path / "data"  # all missing = all stale
+        with caplog.at_level(logging.WARNING, logger="market_data.health"):
+            health_check(data_dir=root)
+        assert any("summary" in r.message.lower() for r in caplog.records)
+
+    def test_summary_info_when_all_fresh(self, tmp_path, caplog):
+        root = tmp_path / "data"
+        for dt in ("ohlcv", "options", "fundamentals", "macro"):
+            _write_parquet(root / dt / "TEST.parquet", age_days=0.1)
+        with caplog.at_level(logging.INFO, logger="market_data.health"):
+            health_check(data_dir=root)
+        messages = [r.message for r in caplog.records]
+        assert any("summary" in m.lower() and "fresh" in m.lower() for m in messages)
+
+    def test_mixed_statuses(self, tmp_path, caplog):
+        root = tmp_path / "data"
+        _write_parquet(root / "ohlcv" / "A.parquet", age_days=0.5)     # fresh
+        _write_parquet(root / "options" / "B.parquet", age_days=20.0)  # stale
+        result = health_check(data_dir=root)
+        assert result["ohlcv"]["is_stale"] is False
+        assert result["options"]["is_stale"] is True


### PR DESCRIPTION
## Summary

- Adds `src/market_data/health.py` with `health_check(data_dir=None)` that scans parquet file mtimes across `ohlcv/`, `options/`, `fundamentals/`, and `macro/` subdirectories
- Returns a structured report per data type: `last_updated`, `age_days`, `is_stale`, `expected_within_days` (thresholds: ohlcv 2d, options 14d, fundamentals 35d, macro 7d)
- Missing directories and empty directories are treated as stale
- Logs per-type status at INFO/WARNING and a summary line; uses the existing `setup_logging()` from `logging_config.py`
- Registers `market-data-health` CLI entry point in `pyproject.toml`; exits with code 1 if any type is stale
- Adds 27 tests in `tests/test_health.py` using `tmp_path` — never touches `data/`

## Test plan

- [x] `pytest tests/test_health.py` — 27/27 passed
- [x] `ruff check src/market_data/health.py tests/test_health.py` — clean
- [x] All 4 data types covered (fresh, stale, missing dir, empty dir)
- [x] Report structure validated (all 4 keys present with correct types)
- [x] Most-recent-file selection verified

Closes #33