### PR TITLE
Add centralized configuration via config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,97 @@
+# config.yaml — centralized configuration for the market_data pipeline
+# All paths are relative to the repository root and are resolved to absolute
+# paths at runtime by src/market_data/config.py.
+
+# ---------------------------------------------------------------------------
+# collection: data-gathering frequencies, batch sizes, and lookback windows
+# ---------------------------------------------------------------------------
+collection:
+  # Years of OHLCV history to pull when a ticker is first onboarded
+  history_years: 10
+
+  # Tickers to onboard per pipeline run (stock equities only; ETFs are
+  # priority-onboarded outside this limit)
+  batch_size: 50
+
+  # Options chain: tickers processed per run across the rolling cycle
+  options_batch_size: 50
+
+  # Options chain: nearest N expiration dates to fetch per ticker
+  options_max_expiries: 4
+
+  # Days between full ticker-list refreshes (iShares holdings re-download)
+  ticker_refresh_days: 90
+
+  # Days between fundamentals snapshots (monthly cadence)
+  fundamentals_refresh_days: 30
+
+  # Earliest date for bootstrapping FRED macro series
+  macro_start: "1990-01-01"
+
+# ---------------------------------------------------------------------------
+# macro: FRED series to collect by default, with human-readable descriptions
+# ---------------------------------------------------------------------------
+macro:
+  series:
+    # Daily
+    DFF:      "Effective Federal Funds Rate"
+    T10Y2Y:   "10yr minus 2yr Treasury yield spread"
+    # Monthly
+    CPIAUCSL: "CPI All Urban Consumers (headline)"
+    CPILFESL: "Core CPI (ex food & energy)"
+    PCEPI:    "PCE Price Index"
+    PCEPILFE: "Core PCE"
+    UNRATE:   "Unemployment Rate"
+    PAYEMS:   "Nonfarm Payrolls (thousands of jobs)"
+    # Quarterly
+    GDPC1:    "Real GDP (chained 2017 dollars)"
+    GDP:      "Nominal GDP"
+
+# ---------------------------------------------------------------------------
+# indices: market index and rate symbols fetched by fetch_indices.py
+# ---------------------------------------------------------------------------
+indices:
+  symbols:
+    - "^VIX"   # CBOE Volatility Index
+    - "^TNX"   # 10-year Treasury yield
+    - "^TYX"   # 30-year Treasury yield
+    - "^FVX"   # 5-year Treasury yield
+    - "^IRX"   # 13-week T-bill yield
+    - "ZQ=F"   # 30-day Fed Funds Futures (front month)
+    - "^GSPC"  # S&P 500 index level
+
+# ---------------------------------------------------------------------------
+# paths: data and log directories, relative to repo root
+# ---------------------------------------------------------------------------
+paths:
+  data_dir:          "data"
+  ohlcv_dir:         "data/ohlcv"
+  options_dir:       "data/options"
+  fundamentals_dir:  "data/fundamentals"
+  macro_dir:         "data/macro"
+  indices_dir:       "data/indices"
+  logs_dir:          "logs"
+  state_file:        "state.json"
+  tickers_file:      "tickers.csv"
+  metrics_file:      "logs/metrics.json"
+
+# ---------------------------------------------------------------------------
+# sources: yfinance and other data-source settings
+# ---------------------------------------------------------------------------
+sources:
+  # Seconds to sleep between successive yfinance API calls — be polite
+  sleep_between_calls:
+    ohlcv:         5
+    options:       5
+    fundamentals:  2
+    indices:       3
+
+# ---------------------------------------------------------------------------
+# health: maximum acceptable age (days) for each data type
+# ---------------------------------------------------------------------------
+health:
+  freshness_days:
+    ohlcv:         2   # daily equity prices
+    options:       14  # options cycle covers ~500 tickers over ~10 days
+    fundamentals:  35  # monthly snapshot run
+    macro:         7   # FRED data; some series are monthly

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "requests>=2.31",
   "fredapi>=0.5",
   "python-dotenv>=1.0",
+  "pyyaml>=6.0",
 ]
 
 [project.scripts]

--- a/src/market_data/config.py
+++ b/src/market_data/config.py
@@ -1,0 +1,186 @@
+"""
+config.py
+---------
+Centralized configuration loader for the market_data pipeline.
+
+Loads ``config.yaml`` once at import time and exposes a ``cfg`` singleton.
+All other modules read their tunable constants from ``cfg`` at startup,
+falling back to the same hardcoded defaults they previously embedded directly.
+
+Config file location
+--------------------
+By default the loader looks for ``config.yaml`` at the repository root
+(three directory levels above this file: ``src/market_data/config.py``
+→ ``src/market_data/`` → ``src/`` → repo root).
+
+Tests can override the location by setting the environment variable
+``MARKET_DATA_CONFIG`` to an absolute path before importing this module
+(or by calling ``reload_config(path)`` from test fixtures).
+
+Usage
+-----
+    from market_data.config import cfg
+
+    batch_size = cfg.get("collection.batch_size", 50)
+    data_path  = cfg.resolve_path("paths.ohlcv_dir", "data/ohlcv")
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Repo root detection
+# ---------------------------------------------------------------------------
+
+# config.py lives at src/market_data/config.py; go up three levels to reach
+# the repository root where config.yaml is stored.
+_REPO_ROOT: Path = Path(__file__).resolve().parent.parent.parent
+
+
+# ---------------------------------------------------------------------------
+# YAML loading (graceful degradation if PyYAML not installed)
+# ---------------------------------------------------------------------------
+
+def _load_yaml(path: Path) -> dict:
+    """Load a YAML file and return its contents as a dict.
+
+    Returns an empty dict if the file is missing, unreadable, or if PyYAML
+    is not installed — so modules that read from ``cfg`` always get their
+    hardcoded fallback defaults rather than crashing.
+    """
+    if not path.exists():
+        return {}
+    try:
+        import yaml  # type: ignore[import]
+        with open(path, encoding="utf-8") as fh:
+            data = yaml.safe_load(fh)
+        return data if isinstance(data, dict) else {}
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# Config class
+# ---------------------------------------------------------------------------
+
+class Config:
+    """Thin wrapper around a nested dict that provides safe dot-key access
+    and path resolution relative to the repository root.
+    """
+
+    def __init__(self, data: dict, root: Path) -> None:
+        self._data = data
+        self.root = root
+
+    # ------------------------------------------------------------------
+    # Value access
+    # ------------------------------------------------------------------
+
+    def get(self, key: str | list[str], default: Any = None) -> Any:
+        """Retrieve a config value by dot-separated key string or key list.
+
+        Parameters
+        ----------
+        key:
+            Either a dot-separated string (``"collection.batch_size"``) or a
+            list of strings (``["collection", "batch_size"]``).
+        default:
+            Value returned when *any* segment of the path is missing or the
+            value at that path is ``None``.
+
+        Examples
+        --------
+        >>> cfg.get("collection.batch_size", 50)
+        50
+        >>> cfg.get(["health", "freshness_days"], {})
+        {'ohlcv': 2, 'options': 14, 'fundamentals': 35, 'macro': 7}
+        """
+        keys = key.split(".") if isinstance(key, str) else list(key)
+        node: Any = self._data
+        for k in keys:
+            if not isinstance(node, dict) or k not in node:
+                return default
+            node = node[k]
+        return node if node is not None else default
+
+    # ------------------------------------------------------------------
+    # Path helpers
+    # ------------------------------------------------------------------
+
+    def resolve_path(self, key: str, default: str = "") -> Path:
+        """Return an absolute ``Path`` for a config path value.
+
+        The raw string is resolved relative to the repository root so that
+        relative paths like ``"data/ohlcv"`` work regardless of the current
+        working directory.
+
+        Parameters
+        ----------
+        key:
+            Dot-separated key pointing to the path string in the config.
+        default:
+            Fallback string if the key is missing.
+        """
+        raw = self.get(key, default)
+        return (self.root / raw).resolve()
+
+
+# ---------------------------------------------------------------------------
+# Singleton — loaded once at import time
+# ---------------------------------------------------------------------------
+
+def _build_config() -> Config:
+    """Locate and load config.yaml, returning a ready ``Config`` instance."""
+    env_path = os.environ.get("MARKET_DATA_CONFIG", "")
+    if env_path:
+        config_path = Path(env_path)
+        # When a custom path is given in tests, use its parent as root so
+        # path resolution stays consistent with where the file lives.
+        root = config_path.parent
+    else:
+        config_path = _REPO_ROOT / "config.yaml"
+        root = _REPO_ROOT
+
+    data = _load_yaml(config_path)
+    return Config(data, root)
+
+
+cfg: Config = _build_config()
+
+
+# ---------------------------------------------------------------------------
+# Test helper
+# ---------------------------------------------------------------------------
+
+def reload_config(path: Path | None = None) -> Config:
+    """Reload ``cfg`` from *path* (or the default location if None).
+
+    Intended for use in test fixtures that need to inject a temporary
+    config file.  Updates the module-level ``cfg`` singleton in place so
+    that callers which have already done ``from market_data.config import cfg``
+    will see the new values via attribute access on the returned object.
+
+    Returns the new ``Config`` so callers can also rebind their local name.
+
+    Note: Module-level constants that were already evaluated at import time
+    (e.g. ``health.FRESHNESS_WINDOWS``) are **not** re-evaluated; only future
+    calls to ``cfg.get()`` will see the new values.
+    """
+    global cfg  # noqa: PLW0603
+    if path is not None:
+        root = path.parent
+        data = _load_yaml(path)
+    else:
+        env_path = os.environ.get("MARKET_DATA_CONFIG", "")
+        if env_path:
+            p = Path(env_path)
+            root = p.parent
+            data = _load_yaml(p)
+        else:
+            root = _REPO_ROOT
+            data = _load_yaml(_REPO_ROOT / "config.yaml")
+    cfg = Config(data, root)
+    return cfg

--- a/src/market_data/fetch.py
+++ b/src/market_data/fetch.py
@@ -20,11 +20,13 @@ from pathlib import Path
 import pandas as pd
 import yfinance as yf
 
+from market_data.config import cfg as _cfg
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
 
-DEFAULT_HISTORY_YEARS = 10
+DEFAULT_HISTORY_YEARS: int = _cfg.get("collection.history_years", 10)
 OHLCV_COLS = ["date", "symbol", "open", "high", "low", "close", "volume"]
 
 

--- a/src/market_data/fetch_fundamentals.py
+++ b/src/market_data/fetch_fundamentals.py
@@ -46,14 +46,16 @@ from pathlib import Path
 import pandas as pd
 import yfinance as yf
 
+from market_data.config import cfg as _cfg
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
 
-FUNDAMENTALS_DIR = Path("data/fundamentals")
-SLEEP_BETWEEN_CALLS = 2  # seconds — .info is lighter than a full history pull
+FUNDAMENTALS_DIR = Path(_cfg.get("paths.fundamentals_dir", "data/fundamentals"))
+SLEEP_BETWEEN_CALLS: int = _cfg.get("sources.sleep_between_calls.fundamentals", 2)
 
 # Mapping: our column name → yfinance info key
 INFO_FIELDS: dict[str, str] = {

--- a/src/market_data/fetch_indices.py
+++ b/src/market_data/fetch_indices.py
@@ -29,6 +29,7 @@ import time
 from datetime import date
 from pathlib import Path
 
+from market_data.config import cfg as _cfg
 from market_data.fetch import (
     DEFAULT_HISTORY_YEARS,
     fetch_history,
@@ -43,18 +44,21 @@ logger = logging.getLogger(__name__)
 # Configuration
 # ---------------------------------------------------------------------------
 
-INDEX_SYMBOLS: list[str] = [
-    "^VIX",   # CBOE Volatility Index
-    "^TNX",   # 10-year Treasury yield
-    "^TYX",   # 30-year Treasury yield
-    "^FVX",   # 5-year Treasury yield
-    "^IRX",   # 13-week T-bill yield
-    "ZQ=F",   # 30-day Fed Funds Futures (front month)
-    "^GSPC",  # S&P 500 index level
-]
+INDEX_SYMBOLS: list[str] = _cfg.get(
+    "indices.symbols",
+    [
+        "^VIX",   # CBOE Volatility Index
+        "^TNX",   # 10-year Treasury yield
+        "^TYX",   # 30-year Treasury yield
+        "^FVX",   # 5-year Treasury yield
+        "^IRX",   # 13-week T-bill yield
+        "ZQ=F",   # 30-day Fed Funds Futures (front month)
+        "^GSPC",  # S&P 500 index level
+    ],
+)
 
-INDICES_DIR = Path("data/indices")
-SLEEP_BETWEEN_CALLS = 3  # seconds
+INDICES_DIR = Path(_cfg.get("paths.indices_dir", "data/indices"))
+SLEEP_BETWEEN_CALLS: int = _cfg.get("sources.sleep_between_calls.indices", 3)
 
 
 # ---------------------------------------------------------------------------

--- a/src/market_data/fetch_macro.py
+++ b/src/market_data/fetch_macro.py
@@ -46,33 +46,40 @@ from pathlib import Path
 
 import pandas as pd
 
+from market_data.config import cfg as _cfg
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
 
-MACRO_DIR = Path("data/macro")
+MACRO_DIR = Path(_cfg.get("paths.macro_dir", "data/macro"))
 
 # Default bootstrap start date — FRED has data going back decades for most series
-DEFAULT_START = "1990-01-01"
+DEFAULT_START: str = _cfg.get("collection.macro_start", "1990-01-01")
 
-# Series to collect by default, grouped by frequency (for documentation clarity)
-DEFAULT_SERIES: list[str] = [
-    # Daily
-    "DFF",       # Effective Federal Funds Rate
-    "T10Y2Y",    # 10yr minus 2yr Treasury yield spread
-    # Monthly
-    "CPIAUCSL",  # CPI headline
-    "CPILFESL",  # Core CPI
-    "PCEPI",     # PCE Price Index
-    "PCEPILFE",  # Core PCE
-    "UNRATE",    # Unemployment Rate
-    "PAYEMS",    # Nonfarm Payrolls
-    # Quarterly
-    "GDPC1",     # Real GDP
-    "GDP",       # Nominal GDP
-]
+# Series to collect by default — keys of the macro.series mapping in config.yaml
+DEFAULT_SERIES: list[str] = list(
+    _cfg.get(
+        "macro.series",
+        {
+            # Daily
+            "DFF":      "Effective Federal Funds Rate",
+            "T10Y2Y":   "10yr minus 2yr Treasury yield spread",
+            # Monthly
+            "CPIAUCSL": "CPI All Urban Consumers (headline)",
+            "CPILFESL": "Core CPI (ex food & energy)",
+            "PCEPI":    "PCE Price Index",
+            "PCEPILFE": "Core PCE",
+            "UNRATE":   "Unemployment Rate",
+            "PAYEMS":   "Nonfarm Payrolls",
+            # Quarterly
+            "GDPC1":    "Real GDP (chained 2017 dollars)",
+            "GDP":      "Nominal GDP",
+        },
+    ).keys()
+)
 
 
 # ---------------------------------------------------------------------------

--- a/src/market_data/fetch_options.py
+++ b/src/market_data/fetch_options.py
@@ -59,19 +59,21 @@ from pathlib import Path
 import pandas as pd
 import yfinance as yf
 
+from market_data.config import cfg as _cfg
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
 
-OPTIONS_DIR = Path("data/options")
-STATE_FILE = Path("state.json")
-TICKERS_FILE = Path("tickers.csv")
+OPTIONS_DIR = Path(_cfg.get("paths.options_dir", "data/options"))
+STATE_FILE = Path(_cfg.get("paths.state_file", "state.json"))
+TICKERS_FILE = Path(_cfg.get("paths.tickers_file", "tickers.csv"))
 
-DEFAULT_BATCH_SIZE = 50
-DEFAULT_MAX_EXPIRIES = 4
-SLEEP_BETWEEN_CALLS = 5  # seconds
+DEFAULT_BATCH_SIZE: int = _cfg.get("collection.options_batch_size", 50)
+DEFAULT_MAX_EXPIRIES: int = _cfg.get("collection.options_max_expiries", 4)
+SLEEP_BETWEEN_CALLS: int = _cfg.get("sources.sleep_between_calls.options", 5)
 
 OPTIONS_COLS = [
     "snapshot_date",

--- a/src/market_data/health.py
+++ b/src/market_data/health.py
@@ -31,6 +31,8 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+from market_data.config import cfg as _cfg
+
 logger = logging.getLogger(__name__)
 
 # Subdirectory names under the data root, keyed by data-type label
@@ -42,14 +44,17 @@ _SUBDIR_NAMES: dict[str, str] = {
 }
 
 # Maximum acceptable age (days) for the most recently modified file
-FRESHNESS_WINDOWS: dict[str, int] = {
-    "ohlcv": 2,
-    "options": 14,
-    "fundamentals": 35,
-    "macro": 7,
-}
+FRESHNESS_WINDOWS: dict[str, int] = _cfg.get(
+    "health.freshness_days",
+    {
+        "ohlcv": 2,
+        "options": 14,
+        "fundamentals": 35,
+        "macro": 7,
+    },
+)
 
-_DEFAULT_DATA_DIR = Path("data")
+_DEFAULT_DATA_DIR = Path(_cfg.get("paths.data_dir", "data"))
 
 
 def health_check(data_dir: Path | None = None) -> dict[str, dict]:

--- a/src/market_data/orchestrator.py
+++ b/src/market_data/orchestrator.py
@@ -51,6 +51,7 @@ from pathlib import Path
 
 import pandas as pd
 
+from market_data.config import cfg as _cfg
 from market_data.fetch import DEFAULT_HISTORY_YEARS, fetch_history, fetch_incremental, save_ticker_data
 from market_data import metrics
 
@@ -60,16 +61,16 @@ logger = logging.getLogger(__name__)
 # Paths & defaults
 # ---------------------------------------------------------------------------
 
-STATE_FILE = Path("state.json")
-TICKERS_FILE = Path("tickers.csv")
-DATA_DIR = Path("data/ohlcv")
+STATE_FILE = Path(_cfg.get("paths.state_file", "state.json"))
+TICKERS_FILE = Path(_cfg.get("paths.tickers_file", "tickers.csv"))
+DATA_DIR = Path(_cfg.get("paths.ohlcv_dir", "data/ohlcv"))
 
-DEFAULT_BATCH_SIZE = 50
-SLEEP_BETWEEN_CALLS = 5  # seconds; be polite to the yfinance endpoint
-TICKER_REFRESH_DAYS = 90
-FUNDAMENTALS_REFRESH_DAYS = 30
-DEFAULT_OPTIONS_BATCH_SIZE = 50
-DEFAULT_MAX_EXPIRIES = 4
+DEFAULT_BATCH_SIZE: int = _cfg.get("collection.batch_size", 50)
+SLEEP_BETWEEN_CALLS: int = _cfg.get("sources.sleep_between_calls.ohlcv", 5)
+TICKER_REFRESH_DAYS: int = _cfg.get("collection.ticker_refresh_days", 90)
+FUNDAMENTALS_REFRESH_DAYS: int = _cfg.get("collection.fundamentals_refresh_days", 30)
+DEFAULT_OPTIONS_BATCH_SIZE: int = _cfg.get("collection.options_batch_size", 50)
+DEFAULT_MAX_EXPIRIES: int = _cfg.get("collection.options_max_expiries", 4)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,333 @@
+"""
+tests/test_config.py
+--------------------
+Tests for the centralized configuration loader (src/market_data/config.py).
+
+All tests are self-contained: they either use the real config.yaml that ships
+with the repo (round-trip checks) or write a minimal temp file to exercise
+path resolution and override logic.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_config(path: Path, data: dict) -> None:
+    """Write *data* as YAML to *path*."""
+    path.write_text(yaml.dump(data), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Basic loading
+# ---------------------------------------------------------------------------
+
+class TestConfigLoads:
+    def test_cfg_singleton_exists(self):
+        from market_data.config import cfg
+        assert cfg is not None
+
+    def test_cfg_is_config_instance(self):
+        from market_data.config import Config, cfg
+        assert isinstance(cfg, Config)
+
+    def test_loads_without_error(self):
+        """Importing config must never raise even if YAML is missing."""
+        import market_data.config  # noqa: F401  — just verify no ImportError
+
+
+# ---------------------------------------------------------------------------
+# Top-level section presence
+# ---------------------------------------------------------------------------
+
+class TestExpectedSections:
+    @pytest.mark.parametrize("section", [
+        "collection",
+        "macro",
+        "indices",
+        "paths",
+        "sources",
+        "health",
+    ])
+    def test_section_present(self, section):
+        from market_data.config import cfg
+        assert cfg.get(section) is not None, f"Missing top-level section: {section!r}"
+
+
+# ---------------------------------------------------------------------------
+# Collection section
+# ---------------------------------------------------------------------------
+
+class TestCollectionConfig:
+    def test_history_years_is_int(self):
+        from market_data.config import cfg
+        assert isinstance(cfg.get("collection.history_years"), int)
+
+    def test_history_years_value(self):
+        from market_data.config import cfg
+        assert cfg.get("collection.history_years") == 10
+
+    def test_batch_size_is_int(self):
+        from market_data.config import cfg
+        assert isinstance(cfg.get("collection.batch_size"), int)
+
+    def test_batch_size_value(self):
+        from market_data.config import cfg
+        assert cfg.get("collection.batch_size") == 50
+
+    def test_options_batch_size_value(self):
+        from market_data.config import cfg
+        assert cfg.get("collection.options_batch_size") == 50
+
+    def test_options_max_expiries_value(self):
+        from market_data.config import cfg
+        assert cfg.get("collection.options_max_expiries") == 4
+
+    def test_ticker_refresh_days_value(self):
+        from market_data.config import cfg
+        assert cfg.get("collection.ticker_refresh_days") == 90
+
+    def test_fundamentals_refresh_days_value(self):
+        from market_data.config import cfg
+        assert cfg.get("collection.fundamentals_refresh_days") == 30
+
+    def test_macro_start_is_string(self):
+        from market_data.config import cfg
+        assert isinstance(cfg.get("collection.macro_start"), str)
+
+
+# ---------------------------------------------------------------------------
+# Health / freshness section
+# ---------------------------------------------------------------------------
+
+class TestHealthConfig:
+    def test_freshness_days_present(self):
+        from market_data.config import cfg
+        assert cfg.get("health.freshness_days") is not None
+
+    @pytest.mark.parametrize("data_type,expected", [
+        ("ohlcv", 2),
+        ("options", 14),
+        ("fundamentals", 35),
+        ("macro", 7),
+    ])
+    def test_freshness_value(self, data_type, expected):
+        from market_data.config import cfg
+        fw = cfg.get("health.freshness_days")
+        assert fw[data_type] == expected, (
+            f"health.freshness_days.{data_type} should be {expected}, got {fw[data_type]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Macro series section
+# ---------------------------------------------------------------------------
+
+class TestMacroConfig:
+    def test_series_mapping_present(self):
+        from market_data.config import cfg
+        assert cfg.get("macro.series") is not None
+
+    @pytest.mark.parametrize("series_id", [
+        "DFF", "T10Y2Y",                          # daily
+        "CPIAUCSL", "CPILFESL", "PCEPI",          # monthly CPI/PCE
+        "PCEPILFE", "UNRATE", "PAYEMS",           # monthly employment
+        "GDPC1", "GDP",                           # quarterly GDP
+    ])
+    def test_series_id_present(self, series_id):
+        from market_data.config import cfg
+        series = cfg.get("macro.series")
+        assert series_id in series, f"FRED series {series_id!r} missing from macro.series"
+
+    def test_series_values_are_strings(self):
+        from market_data.config import cfg
+        for sid, desc in cfg.get("macro.series").items():
+            assert isinstance(desc, str), f"macro.series[{sid!r}] description is not a string"
+
+
+# ---------------------------------------------------------------------------
+# Indices section
+# ---------------------------------------------------------------------------
+
+class TestIndicesConfig:
+    def test_symbols_list_present(self):
+        from market_data.config import cfg
+        assert cfg.get("indices.symbols") is not None
+
+    @pytest.mark.parametrize("symbol", ["^VIX", "^TNX", "^GSPC", "ZQ=F"])
+    def test_expected_symbol_present(self, symbol):
+        from market_data.config import cfg
+        assert symbol in cfg.get("indices.symbols"), (
+            f"{symbol!r} missing from indices.symbols"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Paths section
+# ---------------------------------------------------------------------------
+
+class TestPathsConfig:
+    @pytest.mark.parametrize("key", [
+        "paths.data_dir",
+        "paths.ohlcv_dir",
+        "paths.options_dir",
+        "paths.fundamentals_dir",
+        "paths.macro_dir",
+        "paths.indices_dir",
+        "paths.logs_dir",
+        "paths.state_file",
+        "paths.tickers_file",
+        "paths.metrics_file",
+    ])
+    def test_path_key_present(self, key):
+        from market_data.config import cfg
+        assert cfg.get(key) is not None, f"Missing config key: {key!r}"
+
+    def test_resolve_path_returns_absolute(self):
+        from market_data.config import cfg
+        resolved = cfg.resolve_path("paths.ohlcv_dir", "data/ohlcv")
+        assert resolved.is_absolute()
+
+    def test_resolve_path_ends_with_relative_segment(self):
+        from market_data.config import cfg
+        resolved = cfg.resolve_path("paths.ohlcv_dir", "data/ohlcv")
+        assert "ohlcv" in resolved.parts
+
+    def test_resolve_path_missing_key_uses_default(self):
+        from market_data.config import cfg
+        resolved = cfg.resolve_path("paths.nonexistent_key", "data/fallback")
+        assert resolved.is_absolute()
+        assert "fallback" in resolved.parts
+
+
+# ---------------------------------------------------------------------------
+# Sources section
+# ---------------------------------------------------------------------------
+
+class TestSourcesConfig:
+    @pytest.mark.parametrize("pipeline", ["ohlcv", "options", "fundamentals", "indices"])
+    def test_sleep_between_calls_present(self, pipeline):
+        from market_data.config import cfg
+        val = cfg.get(f"sources.sleep_between_calls.{pipeline}")
+        assert isinstance(val, (int, float)), (
+            f"sources.sleep_between_calls.{pipeline} should be numeric, got {val!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Safe-access (get with default)
+# ---------------------------------------------------------------------------
+
+class TestSafeAccess:
+    def test_missing_key_returns_none(self):
+        from market_data.config import cfg
+        assert cfg.get("totally.nonexistent.key") is None
+
+    def test_missing_key_returns_supplied_default(self):
+        from market_data.config import cfg
+        assert cfg.get("totally.nonexistent.key", "fallback") == "fallback"
+
+    def test_missing_key_returns_zero_default(self):
+        from market_data.config import cfg
+        assert cfg.get("totally.nonexistent.key", 0) == 0
+
+    def test_missing_nested_key_returns_default(self):
+        from market_data.config import cfg
+        # "collection" exists but "collection.nonexistent" does not
+        assert cfg.get("collection.nonexistent_key", 999) == 999
+
+    def test_list_key_syntax(self):
+        from market_data.config import cfg
+        # List-of-keys form should work identically to dot-string form
+        v1 = cfg.get("collection.batch_size")
+        v2 = cfg.get(["collection", "batch_size"])
+        assert v1 == v2
+
+
+# ---------------------------------------------------------------------------
+# Module-level constant propagation
+# ---------------------------------------------------------------------------
+
+class TestModuleConstants:
+    """Verify that updated modules actually read their values from config."""
+
+    def test_health_freshness_windows(self):
+        from market_data.health import FRESHNESS_WINDOWS
+        assert FRESHNESS_WINDOWS["ohlcv"] == 2
+        assert FRESHNESS_WINDOWS["options"] == 14
+        assert FRESHNESS_WINDOWS["fundamentals"] == 35
+        assert FRESHNESS_WINDOWS["macro"] == 7
+
+    def test_fetch_history_years(self):
+        from market_data.fetch import DEFAULT_HISTORY_YEARS
+        assert DEFAULT_HISTORY_YEARS == 10
+
+    def test_orchestrator_batch_size(self):
+        from market_data.orchestrator import DEFAULT_BATCH_SIZE
+        assert DEFAULT_BATCH_SIZE == 50
+
+    def test_orchestrator_refresh_days(self):
+        from market_data.orchestrator import (
+            FUNDAMENTALS_REFRESH_DAYS,
+            TICKER_REFRESH_DAYS,
+        )
+        assert TICKER_REFRESH_DAYS == 90
+        assert FUNDAMENTALS_REFRESH_DAYS == 30
+
+    def test_orchestrator_options_defaults(self):
+        from market_data.orchestrator import DEFAULT_MAX_EXPIRIES, DEFAULT_OPTIONS_BATCH_SIZE
+        assert DEFAULT_OPTIONS_BATCH_SIZE == 50
+        assert DEFAULT_MAX_EXPIRIES == 4
+
+    def test_fetch_macro_default_series(self):
+        from market_data.fetch_macro import DEFAULT_SERIES
+        assert "DFF" in DEFAULT_SERIES
+        assert "CPIAUCSL" in DEFAULT_SERIES
+        assert "GDPC1" in DEFAULT_SERIES
+
+    def test_fetch_indices_symbols(self):
+        from market_data.fetch_indices import INDEX_SYMBOLS
+        assert "^VIX" in INDEX_SYMBOLS
+        assert "^GSPC" in INDEX_SYMBOLS
+
+
+# ---------------------------------------------------------------------------
+# Custom config file override (reload_config)
+# ---------------------------------------------------------------------------
+
+class TestConfigOverride:
+    def test_reload_from_custom_file(self, tmp_path):
+        """reload_config() with a tmp file returns a Config with the new data."""
+        custom = tmp_path / "custom.yaml"
+        _write_config(custom, {"collection": {"batch_size": 99}})
+
+        from market_data.config import reload_config
+        custom_cfg = reload_config(path=custom)
+        assert custom_cfg.get("collection.batch_size") == 99
+
+    def test_reload_missing_key_returns_default(self, tmp_path):
+        custom = tmp_path / "partial.yaml"
+        _write_config(custom, {"collection": {}})
+
+        from market_data.config import reload_config
+        custom_cfg = reload_config(path=custom)
+        assert custom_cfg.get("collection.batch_size", 50) == 50
+
+    def test_reload_restores_original(self, tmp_path):
+        """Calling reload_config(None) re-reads the default config.yaml."""
+        custom = tmp_path / "override.yaml"
+        _write_config(custom, {"collection": {"batch_size": 1}})
+
+        from market_data.config import reload_config
+        reload_config(path=custom)
+        # Restore
+        original_cfg = reload_config(path=None)
+        # Should have the real value back
+        assert original_cfg.get("collection.batch_size") == 50


### PR DESCRIPTION
## Summary

- Adds `config.yaml` at the repo root with sections for `collection`, `macro`, `indices`, `paths`, `sources`, and `health`
- Adds `src/market_data/config.py` — a `Config` class loaded once at import, exposing `cfg.get("dot.key", default)` and `cfg.resolve_path()` for absolute path resolution relative to the repo root
- Updates `orchestrator.py`, `fetch.py`, `fetch_macro.py`, `fetch_options.py`, `fetch_fundamentals.py`, `fetch_indices.py`, and `health.py` to initialize their module-level constants from `cfg` with the same values as before (no behaviour change)
- Adds `tests/test_config.py` with 72 tests: loading, section/key presence, value correctness, path resolution, safe-access defaults, module propagation, and custom-file override via `reload_config()`
- Adds `pyyaml>=6.0` to dependencies; gracefully degrades to hardcoded defaults if YAML is missing

## Test plan

- [x] `pytest --tb=short` — 220/220 passed (72 new in test_config.py)
- [x] `ruff check src/ tests/` — no issues
- [x] All existing tests unchanged (health, fetch, orchestrator, etc.)

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)