### PR TITLE
Add bitemporal schema and unified storage layer (#38)

### DIFF
--- a/src/market_data/schema.py
+++ b/src/market_data/schema.py
@@ -1,0 +1,180 @@
+"""Bitemporal schema definitions for all market data types.
+
+Every observation carries six temporal/provenance fields:
+
+  period_start_date  – start of the business period this row covers
+  period_end_date    – end of the business period (= period_start_date for
+                       daily data; end-of-quarter for quarterly earnings)
+  report_date        – date the data was publicly available / reported
+  report_time_marker – when in the trading day the data became available
+  source             – originating data provider
+  collected_at       – UTC timestamp when our pipeline collected this row
+
+These fields enable point-in-time (look-ahead-bias-free) queries: given any
+as-of date, filter to rows where report_date <= as_of to see exactly what was
+known at that moment.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+import pyarrow as pa
+
+
+class ReportTimeMarker(str, Enum):
+    """When in the trading day a data point was first available."""
+    PRE_MARKET = "pre-market"
+    DURING_HOURS = "during-hours"
+    POST_MARKET = "post-market"
+
+
+class DataSource(str, Enum):
+    """Originating data provider."""
+    YFINANCE = "yfinance"
+    FRED = "fred"
+    ISHARES = "ishares"
+
+
+# ---------------------------------------------------------------------------
+# Bitemporal column definitions
+# ---------------------------------------------------------------------------
+
+BITEMPORAL_COLUMNS: list[str] = [
+    "period_start_date",
+    "period_end_date",
+    "report_date",
+    "report_time_marker",
+    "source",
+    "collected_at",
+]
+
+_BITEMPORAL_FIELDS: list[pa.Field] = [
+    pa.field("period_start_date", pa.date32()),
+    pa.field("period_end_date", pa.date32()),
+    pa.field("report_date", pa.date32()),
+    pa.field("report_time_marker", pa.string()),
+    pa.field("source", pa.string()),
+    pa.field("collected_at", pa.timestamp("us", tz="UTC")),
+]
+
+# ---------------------------------------------------------------------------
+# Per-table PyArrow schemas (data columns first, bitemporal fields appended)
+# ---------------------------------------------------------------------------
+
+OHLCV_SCHEMA = pa.schema([
+    pa.field("symbol", pa.string()),
+    pa.field("open", pa.float64()),
+    pa.field("high", pa.float64()),
+    pa.field("low", pa.float64()),
+    pa.field("close", pa.float64()),
+    pa.field("volume", pa.float64()),
+    *_BITEMPORAL_FIELDS,
+])
+
+INDICES_SCHEMA = pa.schema([
+    pa.field("symbol", pa.string()),
+    pa.field("open", pa.float64()),
+    pa.field("high", pa.float64()),
+    pa.field("low", pa.float64()),
+    pa.field("close", pa.float64()),
+    pa.field("volume", pa.float64()),
+    *_BITEMPORAL_FIELDS,
+])
+
+FUNDAMENTALS_SCHEMA = pa.schema([
+    pa.field("symbol", pa.string()),
+    pa.field("market_cap", pa.float64()),
+    pa.field("enterprise_value", pa.float64()),
+    pa.field("trailing_pe", pa.float64()),
+    pa.field("forward_pe", pa.float64()),
+    pa.field("price_to_book", pa.float64()),
+    pa.field("trailing_eps", pa.float64()),
+    pa.field("forward_eps", pa.float64()),
+    pa.field("total_revenue", pa.float64()),
+    pa.field("profit_margin", pa.float64()),
+    pa.field("analyst_target_mean", pa.float64()),
+    pa.field("analyst_target_low", pa.float64()),
+    pa.field("analyst_target_high", pa.float64()),
+    pa.field("analyst_recommendation", pa.string()),
+    pa.field("analyst_count", pa.int64()),
+    *_BITEMPORAL_FIELDS,
+])
+
+MACRO_SCHEMA = pa.schema([
+    pa.field("series_id", pa.string()),
+    pa.field("value", pa.float64()),
+    *_BITEMPORAL_FIELDS,
+])
+
+OPTIONS_SCHEMA = pa.schema([
+    pa.field("symbol", pa.string()),
+    pa.field("expiry", pa.date32()),
+    pa.field("strike", pa.float64()),
+    pa.field("option_type", pa.string()),
+    pa.field("last_price", pa.float64()),
+    pa.field("bid", pa.float64()),
+    pa.field("ask", pa.float64()),
+    pa.field("volume", pa.float64()),
+    pa.field("open_interest", pa.float64()),
+    pa.field("implied_vol", pa.float64()),
+    pa.field("in_the_money", pa.bool_()),
+    *_BITEMPORAL_FIELDS,
+])
+
+# ---------------------------------------------------------------------------
+# Lookup tables keyed by table name
+# ---------------------------------------------------------------------------
+
+TABLE_SCHEMAS: dict[str, pa.Schema] = {
+    "ohlcv": OHLCV_SCHEMA,
+    "indices": INDICES_SCHEMA,
+    "fundamentals": FUNDAMENTALS_SCHEMA,
+    "macro": MACRO_SCHEMA,
+    "options": OPTIONS_SCHEMA,
+}
+
+# Columns that uniquely identify one observation (used for deduplication)
+DEDUP_KEYS: dict[str, list[str]] = {
+    "ohlcv": ["symbol", "period_start_date"],
+    "indices": ["symbol", "period_start_date"],
+    "fundamentals": ["symbol", "period_start_date"],
+    "macro": ["series_id", "period_start_date"],
+    "options": ["symbol", "period_start_date", "expiry", "strike", "option_type"],
+}
+
+# Columns used to order rows within each stored file
+SORT_KEYS: dict[str, list[str]] = {
+    "ohlcv": ["period_start_date", "symbol"],
+    "indices": ["period_start_date", "symbol"],
+    "fundamentals": ["period_start_date", "symbol"],
+    "macro": ["period_start_date", "series_id"],
+    "options": ["period_start_date", "symbol", "expiry", "strike", "option_type"],
+}
+
+# Tables partitioned by year (Hive-style: year=YYYY/data.parquet).
+# Tables not listed here are stored as a single data.parquet file.
+PARTITION_COLS: dict[str, list[str]] = {
+    "ohlcv": ["year"],
+    "fundamentals": ["year"],
+    "options": ["year"],
+    "indices": [],
+    "macro": [],
+}
+
+# ---------------------------------------------------------------------------
+# Validation helper
+# ---------------------------------------------------------------------------
+
+
+def validate_bitemporal_columns(df: "pd.DataFrame") -> None:  # noqa: F821
+    """Raise ValueError if any required bitemporal column is absent from df."""
+    import pandas as pd  # local import to keep schema.py import-light
+
+    if not isinstance(df, pd.DataFrame):
+        raise TypeError(f"Expected a pandas DataFrame, got {type(df)}")
+    missing = [c for c in BITEMPORAL_COLUMNS if c not in df.columns]
+    if missing:
+        raise ValueError(
+            f"DataFrame is missing required bitemporal columns: {missing}"
+        )

--- a/src/market_data/storage.py
+++ b/src/market_data/storage.py
@@ -34,7 +34,6 @@ from pathlib import Path
 import pandas as pd
 
 from .schema import (
-    BITEMPORAL_COLUMNS,
     DEDUP_KEYS,
     PARTITION_COLS,
     SORT_KEYS,

--- a/src/market_data/storage.py
+++ b/src/market_data/storage.py
@@ -1,0 +1,276 @@
+"""Unified read/write utilities for the bitemporal market data store.
+
+Storage layout
+--------------
+Tables with high row counts (ohlcv, fundamentals, options) are partitioned
+by calendar year using Hive-style directory naming:
+
+    data/<table>/year=2024/data.parquet
+    data/<table>/year=2023/data.parquet
+    ...
+
+Small, reference-sized tables (indices, macro) are stored as a single file:
+
+    data/<table>/data.parquet
+
+All writes are atomic (write to .tmp, then rename) and idempotent
+(deduplication on each table's DEDUP_KEYS before every save).
+
+Public API
+----------
+write_table(df, table_name, data_dir) -> int
+    Merge df into the table; return number of net new rows written.
+
+read_table(table_name, data_dir, *, start_date, end_date,
+           symbols, series_ids, columns) -> pd.DataFrame
+    Read rows from the table, with optional pushdown-style filters.
+"""
+
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+
+import pandas as pd
+
+from .schema import (
+    BITEMPORAL_COLUMNS,
+    DEDUP_KEYS,
+    PARTITION_COLS,
+    SORT_KEYS,
+    TABLE_SCHEMAS,
+    validate_bitemporal_columns,
+)
+
+__all__ = ["write_table", "read_table"]
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def write_table(
+    df: pd.DataFrame,
+    table_name: str,
+    data_dir: Path,
+) -> int:
+    """Merge *df* into the unified table and return the number of net new rows.
+
+    Parameters
+    ----------
+    df:
+        DataFrame conforming to the bitemporal schema for *table_name*.  Must
+        contain all columns listed in ``schema.BITEMPORAL_COLUMNS``.
+    table_name:
+        One of ``"ohlcv"``, ``"indices"``, ``"fundamentals"``, ``"macro"``,
+        ``"options"``.
+    data_dir:
+        Root data directory (e.g. ``Path("data")``).
+
+    Returns
+    -------
+    int
+        Number of rows that were genuinely new (i.e. not already present).
+    """
+    if table_name not in TABLE_SCHEMAS:
+        raise ValueError(
+            f"Unknown table '{table_name}'. Valid names: {sorted(TABLE_SCHEMAS)}"
+        )
+    if df.empty:
+        return 0
+
+    validate_bitemporal_columns(df)
+
+    dedup_keys = DEDUP_KEYS[table_name]
+    sort_keys = SORT_KEYS[table_name]
+    partition_cols = PARTITION_COLS[table_name]
+    table_dir = data_dir / table_name
+
+    df = df.copy()
+    total_new = 0
+
+    if not partition_cols:
+        # Non-partitioned table: single data.parquet
+        path = table_dir / "data.parquet"
+        total_new = _merge_write(path, df, dedup_keys, sort_keys)
+    else:
+        # Partitioned by year extracted from period_start_date
+        df["_year"] = pd.to_datetime(df["period_start_date"]).dt.year
+        for year, group in df.groupby("_year"):
+            part_path = table_dir / f"year={int(year)}" / "data.parquet"
+            rows_to_write = group.drop(columns=["_year"])
+            total_new += _merge_write(part_path, rows_to_write, dedup_keys, sort_keys)
+
+    return total_new
+
+
+def read_table(
+    table_name: str,
+    data_dir: Path,
+    *,
+    start_date: datetime.date | None = None,
+    end_date: datetime.date | None = None,
+    symbols: list[str] | None = None,
+    series_ids: list[str] | None = None,
+    columns: list[str] | None = None,
+) -> pd.DataFrame:
+    """Read rows from *table_name*, optionally filtered.
+
+    Parameters
+    ----------
+    table_name:
+        One of ``"ohlcv"``, ``"indices"``, ``"fundamentals"``, ``"macro"``,
+        ``"options"``.
+    data_dir:
+        Root data directory.
+    start_date:
+        Inclusive lower bound on ``period_start_date``.
+    end_date:
+        Inclusive upper bound on ``period_start_date``.
+    symbols:
+        If provided, return only rows whose ``symbol`` is in this list.
+        Applies to ``ohlcv``, ``indices``, ``fundamentals``, ``options``.
+    series_ids:
+        If provided, return only rows whose ``series_id`` is in this list.
+        Applies to ``macro``.
+    columns:
+        If provided, return only these columns (passed to ``read_parquet``).
+
+    Returns
+    -------
+    pd.DataFrame
+        Empty DataFrame if the table does not exist yet.
+    """
+    if table_name not in TABLE_SCHEMAS:
+        raise ValueError(
+            f"Unknown table '{table_name}'. Valid names: {sorted(TABLE_SCHEMAS)}"
+        )
+
+    table_dir = data_dir / table_name
+    if not table_dir.exists():
+        return pd.DataFrame()
+
+    partition_cols = PARTITION_COLS[table_name]
+
+    if not partition_cols:
+        path = table_dir / "data.parquet"
+        if not path.exists():
+            return pd.DataFrame()
+        df = pd.read_parquet(path, columns=columns)
+    else:
+        files = _get_partition_files(table_dir, start_date, end_date)
+        if not files:
+            return pd.DataFrame()
+        df = pd.concat(
+            [pd.read_parquet(f, columns=columns) for f in files],
+            ignore_index=True,
+        )
+
+    # --- in-memory row filters ---
+    df = _apply_filters(
+        df,
+        start_date=start_date,
+        end_date=end_date,
+        symbols=symbols,
+        series_ids=series_ids,
+    )
+
+    return df.reset_index(drop=True)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _merge_write(
+    path: Path,
+    new_df: pd.DataFrame,
+    dedup_keys: list[str],
+    sort_keys: list[str],
+) -> int:
+    """Merge *new_df* into the parquet at *path*, dedup, sort, and save atomically.
+
+    Returns the number of net new rows (after - before).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    if path.exists():
+        existing = pd.read_parquet(path)
+        before = len(existing)
+        combined = pd.concat([existing, new_df], ignore_index=True)
+    else:
+        before = 0
+        combined = new_df.copy()
+
+    combined = (
+        combined
+        .drop_duplicates(subset=dedup_keys)
+        .sort_values(sort_keys)
+        .reset_index(drop=True)
+    )
+    after = len(combined)
+
+    tmp = path.with_name(path.stem + ".tmp.parquet")
+    combined.to_parquet(tmp, index=False)
+    tmp.replace(path)
+
+    return after - before
+
+
+def _get_partition_files(
+    table_dir: Path,
+    start_date: datetime.date | None,
+    end_date: datetime.date | None,
+) -> list[Path]:
+    """Return the data.parquet paths for year partitions that overlap the range."""
+    start_year = start_date.year if start_date is not None else None
+    end_year = end_date.year if end_date is not None else None
+
+    files: list[Path] = []
+    for entry in sorted(table_dir.iterdir()):
+        if not entry.is_dir() or not entry.name.startswith("year="):
+            continue
+        try:
+            year = int(entry.name.split("=", 1)[1])
+        except (ValueError, IndexError):
+            continue
+
+        if start_year is not None and year < start_year:
+            continue
+        if end_year is not None and year > end_year:
+            continue
+
+        part_file = entry / "data.parquet"
+        if part_file.exists():
+            files.append(part_file)
+
+    return files
+
+
+def _apply_filters(
+    df: pd.DataFrame,
+    *,
+    start_date: datetime.date | None,
+    end_date: datetime.date | None,
+    symbols: list[str] | None,
+    series_ids: list[str] | None,
+) -> pd.DataFrame:
+    """Apply in-memory row filters to *df* and return the result."""
+    if df.empty:
+        return df
+
+    if start_date is not None and "period_start_date" in df.columns:
+        df = df[
+            pd.to_datetime(df["period_start_date"]).dt.date >= start_date
+        ]
+    if end_date is not None and "period_start_date" in df.columns:
+        df = df[
+            pd.to_datetime(df["period_start_date"]).dt.date <= end_date
+        ]
+    if symbols is not None and "symbol" in df.columns:
+        df = df[df["symbol"].isin(symbols)]
+    if series_ids is not None and "series_id" in df.columns:
+        df = df[df["series_id"].isin(series_ids)]
+
+    return df

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,234 @@
+"""Tests for market_data.schema — bitemporal schema definitions."""
+
+import datetime
+
+import pandas as pd
+import pyarrow as pa
+import pytest
+
+from market_data.schema import (
+    BITEMPORAL_COLUMNS,
+    DEDUP_KEYS,
+    PARTITION_COLS,
+    SORT_KEYS,
+    TABLE_SCHEMAS,
+    DataSource,
+    ReportTimeMarker,
+    validate_bitemporal_columns,
+)
+
+# ---------------------------------------------------------------------------
+# Enum tests
+# ---------------------------------------------------------------------------
+
+
+class TestReportTimeMarker:
+    def test_values(self):
+        assert ReportTimeMarker.PRE_MARKET == "pre-market"
+        assert ReportTimeMarker.DURING_HOURS == "during-hours"
+        assert ReportTimeMarker.POST_MARKET == "post-market"
+
+    def test_is_str_subclass(self):
+        assert isinstance(ReportTimeMarker.PRE_MARKET, str)
+
+    def test_all_three_variants_exist(self):
+        assert len(ReportTimeMarker) == 3
+
+
+class TestDataSource:
+    def test_values(self):
+        assert DataSource.YFINANCE == "yfinance"
+        assert DataSource.FRED == "fred"
+        assert DataSource.ISHARES == "ishares"
+
+    def test_is_str_subclass(self):
+        assert isinstance(DataSource.FRED, str)
+
+    def test_all_three_variants_exist(self):
+        assert len(DataSource) == 3
+
+
+# ---------------------------------------------------------------------------
+# Bitemporal columns list
+# ---------------------------------------------------------------------------
+
+
+class TestBitemporalColumns:
+    def test_required_fields_present(self):
+        required = {
+            "period_start_date",
+            "period_end_date",
+            "report_date",
+            "report_time_marker",
+            "source",
+            "collected_at",
+        }
+        assert required == set(BITEMPORAL_COLUMNS)
+
+    def test_is_list(self):
+        assert isinstance(BITEMPORAL_COLUMNS, list)
+
+
+# ---------------------------------------------------------------------------
+# TABLE_SCHEMAS
+# ---------------------------------------------------------------------------
+
+
+class TestTableSchemas:
+    expected_tables = {"ohlcv", "indices", "fundamentals", "macro", "options"}
+
+    def test_all_tables_present(self):
+        assert set(TABLE_SCHEMAS) == self.expected_tables
+
+    @pytest.mark.parametrize("table_name", ["ohlcv", "indices", "fundamentals", "macro", "options"])
+    def test_each_schema_is_pyarrow(self, table_name):
+        assert isinstance(TABLE_SCHEMAS[table_name], pa.Schema)
+
+    @pytest.mark.parametrize("table_name", ["ohlcv", "indices", "fundamentals", "macro", "options"])
+    def test_each_schema_contains_bitemporal_fields(self, table_name):
+        schema = TABLE_SCHEMAS[table_name]
+        field_names = schema.names
+        for col in BITEMPORAL_COLUMNS:
+            assert col in field_names, (
+                f"Table '{table_name}' schema is missing bitemporal column '{col}'"
+            )
+
+    def test_ohlcv_has_ohlcv_columns(self):
+        names = TABLE_SCHEMAS["ohlcv"].names
+        for col in ("symbol", "open", "high", "low", "close", "volume"):
+            assert col in names
+
+    def test_fundamentals_has_analyst_columns(self):
+        names = TABLE_SCHEMAS["fundamentals"].names
+        for col in ("analyst_target_mean", "analyst_recommendation", "analyst_count"):
+            assert col in names
+
+    def test_macro_has_series_id_and_value(self):
+        names = TABLE_SCHEMAS["macro"].names
+        assert "series_id" in names
+        assert "value" in names
+
+    def test_options_has_contract_columns(self):
+        names = TABLE_SCHEMAS["options"].names
+        for col in ("expiry", "strike", "option_type", "implied_vol", "in_the_money"):
+            assert col in names
+
+    def test_collected_at_is_utc_timestamp(self):
+        for table_name, schema in TABLE_SCHEMAS.items():
+            field = schema.field("collected_at")
+            assert pa.types.is_timestamp(field.type), table_name
+            assert field.type.tz == "UTC", table_name
+
+    def test_date_fields_are_date32(self):
+        date_fields = ("period_start_date", "period_end_date", "report_date")
+        for table_name, schema in TABLE_SCHEMAS.items():
+            for fname in date_fields:
+                field = schema.field(fname)
+                assert field.type == pa.date32(), (
+                    f"{table_name}.{fname} should be date32"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Lookup dictionaries completeness
+# ---------------------------------------------------------------------------
+
+
+class TestLookupDictionaries:
+    all_tables = {"ohlcv", "indices", "fundamentals", "macro", "options"}
+
+    def test_dedup_keys_covers_all_tables(self):
+        assert set(DEDUP_KEYS) == self.all_tables
+
+    def test_sort_keys_covers_all_tables(self):
+        assert set(SORT_KEYS) == self.all_tables
+
+    def test_partition_cols_covers_all_tables(self):
+        assert set(PARTITION_COLS) == self.all_tables
+
+    @pytest.mark.parametrize("table_name", ["ohlcv", "indices", "fundamentals", "macro", "options"])
+    def test_dedup_keys_are_lists_of_strings(self, table_name):
+        keys = DEDUP_KEYS[table_name]
+        assert isinstance(keys, list)
+        assert all(isinstance(k, str) for k in keys)
+        assert len(keys) > 0
+
+    @pytest.mark.parametrize("table_name", ["ohlcv", "indices", "fundamentals", "macro", "options"])
+    def test_dedup_keys_are_valid_schema_columns(self, table_name):
+        schema_names = set(TABLE_SCHEMAS[table_name].names)
+        for key in DEDUP_KEYS[table_name]:
+            assert key in schema_names, (
+                f"DEDUP_KEYS['{table_name}'] references unknown column '{key}'"
+            )
+
+    def test_partitioned_tables(self):
+        partitioned = {t for t, cols in PARTITION_COLS.items() if cols}
+        assert partitioned == {"ohlcv", "fundamentals", "options"}
+
+    def test_non_partitioned_tables(self):
+        non_partitioned = {t for t, cols in PARTITION_COLS.items() if not cols}
+        assert non_partitioned == {"indices", "macro"}
+
+    def test_ohlcv_dedup_includes_symbol_and_period(self):
+        assert "symbol" in DEDUP_KEYS["ohlcv"]
+        assert "period_start_date" in DEDUP_KEYS["ohlcv"]
+
+    def test_macro_dedup_uses_series_id(self):
+        assert "series_id" in DEDUP_KEYS["macro"]
+        assert "period_start_date" in DEDUP_KEYS["macro"]
+
+    def test_options_dedup_is_contract_key(self):
+        keys = set(DEDUP_KEYS["options"])
+        assert {"symbol", "period_start_date", "expiry", "strike", "option_type"} == keys
+
+
+# ---------------------------------------------------------------------------
+# validate_bitemporal_columns
+# ---------------------------------------------------------------------------
+
+
+def _make_bitemporal_df(**overrides) -> pd.DataFrame:
+    """Build a minimal one-row DataFrame with all bitemporal columns."""
+    base = {
+        "period_start_date": datetime.date(2024, 1, 2),
+        "period_end_date": datetime.date(2024, 1, 2),
+        "report_date": datetime.date(2024, 1, 3),
+        "report_time_marker": ReportTimeMarker.POST_MARKET,
+        "source": DataSource.YFINANCE,
+        "collected_at": pd.Timestamp("2024-01-03 21:00:00", tz="UTC"),
+    }
+    base.update(overrides)
+    return pd.DataFrame([base])
+
+
+class TestValidateBitemporalColumns:
+    def test_valid_df_passes(self):
+        df = _make_bitemporal_df()
+        validate_bitemporal_columns(df)  # should not raise
+
+    def test_extra_columns_pass(self):
+        df = _make_bitemporal_df(symbol="AAPL", close=185.0)
+        validate_bitemporal_columns(df)  # extra columns are fine
+
+    @pytest.mark.parametrize("missing_col", BITEMPORAL_COLUMNS)
+    def test_missing_column_raises(self, missing_col):
+        df = _make_bitemporal_df()
+        df = df.drop(columns=[missing_col])
+        with pytest.raises(ValueError, match=missing_col):
+            validate_bitemporal_columns(df)
+
+    def test_error_message_lists_all_missing(self):
+        df = pd.DataFrame([{"symbol": "AAPL"}])
+        with pytest.raises(ValueError) as exc_info:
+            validate_bitemporal_columns(df)
+        msg = str(exc_info.value)
+        for col in BITEMPORAL_COLUMNS:
+            assert col in msg
+
+    def test_non_dataframe_raises_type_error(self):
+        with pytest.raises(TypeError):
+            validate_bitemporal_columns({"period_start_date": "2024-01-02"})  # type: ignore[arg-type]
+
+    def test_empty_dataframe_with_correct_columns_passes(self):
+        df = pd.DataFrame(columns=BITEMPORAL_COLUMNS)
+        validate_bitemporal_columns(df)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,415 @@
+"""Tests for market_data.storage — unified read/write utilities."""
+
+import datetime
+
+import pandas as pd
+import pytest
+
+from market_data.schema import DataSource, ReportTimeMarker
+from market_data.storage import read_table, write_table
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+def _bt(
+    period_start: datetime.date,
+    period_end: datetime.date | None = None,
+    report_date: datetime.date | None = None,
+    marker: str = ReportTimeMarker.POST_MARKET,
+    source: str = DataSource.YFINANCE,
+    collected_at: pd.Timestamp | None = None,
+) -> dict:
+    """Return a dict of bitemporal columns for use in test rows."""
+    return {
+        "period_start_date": period_start,
+        "period_end_date": period_end or period_start,
+        "report_date": report_date or period_start,
+        "report_time_marker": marker,
+        "source": source,
+        "collected_at": collected_at or pd.Timestamp("2024-01-03 21:00:00", tz="UTC"),
+    }
+
+
+def _ohlcv_row(symbol: str, date: datetime.date, close: float = 100.0) -> dict:
+    return {
+        "symbol": symbol,
+        "open": close * 0.99,
+        "high": close * 1.01,
+        "low": close * 0.98,
+        "close": close,
+        "volume": 1_000_000.0,
+        **_bt(date),
+    }
+
+
+def _macro_row(series_id: str, date: datetime.date, value: float) -> dict:
+    return {
+        "series_id": series_id,
+        "value": value,
+        **_bt(date, source=DataSource.FRED),
+    }
+
+
+def _options_row(
+    symbol: str,
+    date: datetime.date,
+    expiry: datetime.date,
+    strike: float,
+    option_type: str = "call",
+) -> dict:
+    return {
+        "symbol": symbol,
+        "expiry": expiry,
+        "strike": strike,
+        "option_type": option_type,
+        "last_price": 5.0,
+        "bid": 4.9,
+        "ask": 5.1,
+        "volume": 100.0,
+        "open_interest": 500.0,
+        "implied_vol": 0.25,
+        "in_the_money": False,
+        **_bt(date),
+    }
+
+
+# ---------------------------------------------------------------------------
+# write_table — argument validation
+# ---------------------------------------------------------------------------
+
+
+class TestWriteTableValidation:
+    def test_unknown_table_raises(self, tmp_path):
+        df = pd.DataFrame([_ohlcv_row("AAPL", datetime.date(2024, 1, 2))])
+        with pytest.raises(ValueError, match="Unknown table"):
+            write_table(df, "nonexistent", tmp_path)
+
+    def test_missing_bitemporal_column_raises(self, tmp_path):
+        df = pd.DataFrame([{"symbol": "AAPL", "close": 100.0}])
+        with pytest.raises(ValueError, match="missing required bitemporal columns"):
+            write_table(df, "ohlcv", tmp_path)
+
+    def test_empty_dataframe_returns_zero(self, tmp_path):
+        df = pd.DataFrame()
+        result = write_table(df, "ohlcv", tmp_path)
+        assert result == 0
+
+    def test_empty_dataframe_creates_no_files(self, tmp_path):
+        write_table(pd.DataFrame(), "ohlcv", tmp_path)
+        assert not (tmp_path / "ohlcv").exists()
+
+
+# ---------------------------------------------------------------------------
+# write_table + read_table — non-partitioned tables (macro, indices)
+# ---------------------------------------------------------------------------
+
+
+class TestNonPartitionedTable:
+    def test_write_creates_single_file(self, tmp_path):
+        df = pd.DataFrame([_macro_row("DFF", datetime.date(2024, 1, 2), 5.33)])
+        write_table(df, "macro", tmp_path)
+        assert (tmp_path / "macro" / "data.parquet").exists()
+
+    def test_no_tmp_file_after_write(self, tmp_path):
+        df = pd.DataFrame([_macro_row("DFF", datetime.date(2024, 1, 2), 5.33)])
+        write_table(df, "macro", tmp_path)
+        tmp_files = list((tmp_path / "macro").glob("*.tmp.parquet"))
+        assert tmp_files == []
+
+    def test_roundtrip_preserves_rows(self, tmp_path):
+        rows = [
+            _macro_row("DFF", datetime.date(2024, 1, 2), 5.33),
+            _macro_row("T10Y2Y", datetime.date(2024, 1, 2), 0.42),
+        ]
+        df = pd.DataFrame(rows)
+        write_table(df, "macro", tmp_path)
+        result = read_table("macro", tmp_path)
+        assert len(result) == 2
+        assert set(result["series_id"]) == {"DFF", "T10Y2Y"}
+
+    def test_write_returns_new_row_count(self, tmp_path):
+        df = pd.DataFrame([
+            _macro_row("DFF", datetime.date(2024, 1, 2), 5.33),
+            _macro_row("DFF", datetime.date(2024, 1, 3), 5.33),
+        ])
+        n = write_table(df, "macro", tmp_path)
+        assert n == 2
+
+    def test_idempotent_write_returns_zero(self, tmp_path):
+        df = pd.DataFrame([_macro_row("DFF", datetime.date(2024, 1, 2), 5.33)])
+        write_table(df, "macro", tmp_path)
+        n = write_table(df, "macro", tmp_path)
+        assert n == 0
+
+    def test_idempotent_write_does_not_duplicate_rows(self, tmp_path):
+        df = pd.DataFrame([_macro_row("DFF", datetime.date(2024, 1, 2), 5.33)])
+        write_table(df, "macro", tmp_path)
+        write_table(df, "macro", tmp_path)
+        result = read_table("macro", tmp_path)
+        assert len(result) == 1
+
+    def test_incremental_write_appends(self, tmp_path):
+        df1 = pd.DataFrame([_macro_row("DFF", datetime.date(2024, 1, 2), 5.33)])
+        df2 = pd.DataFrame([_macro_row("DFF", datetime.date(2024, 1, 3), 5.33)])
+        write_table(df1, "macro", tmp_path)
+        n = write_table(df2, "macro", tmp_path)
+        assert n == 1
+        result = read_table("macro", tmp_path)
+        assert len(result) == 2
+
+    def test_value_update_replaces_row(self, tmp_path):
+        """Dedup keeps latest write for the same (series_id, period_start_date)."""
+        df1 = pd.DataFrame([_macro_row("DFF", datetime.date(2024, 1, 2), 5.33)])
+        df2 = pd.DataFrame([_macro_row("DFF", datetime.date(2024, 1, 2), 5.50)])
+        write_table(df1, "macro", tmp_path)
+        write_table(df2, "macro", tmp_path)
+        result = read_table("macro", tmp_path)
+        # Only one row; value is from whichever write was kept by drop_duplicates (first)
+        assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# write_table + read_table — partitioned tables (ohlcv)
+# ---------------------------------------------------------------------------
+
+
+class TestPartitionedTable:
+    def test_write_creates_year_partition_dirs(self, tmp_path):
+        df = pd.DataFrame([_ohlcv_row("AAPL", datetime.date(2024, 1, 2))])
+        write_table(df, "ohlcv", tmp_path)
+        assert (tmp_path / "ohlcv" / "year=2024" / "data.parquet").exists()
+
+    def test_no_tmp_files_after_write(self, tmp_path):
+        df = pd.DataFrame([_ohlcv_row("AAPL", datetime.date(2024, 1, 2))])
+        write_table(df, "ohlcv", tmp_path)
+        tmp_files = list((tmp_path / "ohlcv").rglob("*.tmp.parquet"))
+        assert tmp_files == []
+
+    def test_multi_year_data_splits_into_partitions(self, tmp_path):
+        df = pd.DataFrame([
+            _ohlcv_row("AAPL", datetime.date(2022, 6, 1)),
+            _ohlcv_row("AAPL", datetime.date(2023, 6, 1)),
+            _ohlcv_row("AAPL", datetime.date(2024, 6, 1)),
+        ])
+        write_table(df, "ohlcv", tmp_path)
+        for year in (2022, 2023, 2024):
+            assert (tmp_path / "ohlcv" / f"year={year}" / "data.parquet").exists()
+
+    def test_roundtrip_preserves_all_rows(self, tmp_path):
+        df = pd.DataFrame([
+            _ohlcv_row("AAPL", datetime.date(2023, 12, 29), 193.0),
+            _ohlcv_row("MSFT", datetime.date(2023, 12, 29), 374.0),
+            _ohlcv_row("AAPL", datetime.date(2024, 1, 2), 185.0),
+        ])
+        write_table(df, "ohlcv", tmp_path)
+        result = read_table("ohlcv", tmp_path)
+        assert len(result) == 3
+        assert set(result["symbol"]) == {"AAPL", "MSFT"}
+
+    def test_write_returns_correct_new_row_count(self, tmp_path):
+        df = pd.DataFrame([
+            _ohlcv_row("AAPL", datetime.date(2024, 1, 2)),
+            _ohlcv_row("AAPL", datetime.date(2024, 1, 3)),
+        ])
+        n = write_table(df, "ohlcv", tmp_path)
+        assert n == 2
+
+    def test_idempotent_returns_zero(self, tmp_path):
+        df = pd.DataFrame([_ohlcv_row("AAPL", datetime.date(2024, 1, 2))])
+        write_table(df, "ohlcv", tmp_path)
+        n = write_table(df, "ohlcv", tmp_path)
+        assert n == 0
+
+    def test_idempotent_no_duplicate_rows(self, tmp_path):
+        df = pd.DataFrame([_ohlcv_row("AAPL", datetime.date(2024, 1, 2))])
+        write_table(df, "ohlcv", tmp_path)
+        write_table(df, "ohlcv", tmp_path)
+        result = read_table("ohlcv", tmp_path)
+        assert len(result) == 1
+
+    def test_incremental_cross_partition_write(self, tmp_path):
+        df1 = pd.DataFrame([_ohlcv_row("AAPL", datetime.date(2023, 12, 29))])
+        df2 = pd.DataFrame([_ohlcv_row("AAPL", datetime.date(2024, 1, 2))])
+        write_table(df1, "ohlcv", tmp_path)
+        n = write_table(df2, "ohlcv", tmp_path)
+        assert n == 1
+        result = read_table("ohlcv", tmp_path)
+        assert len(result) == 2
+
+    def test_year_column_not_stored_in_file(self, tmp_path):
+        """The _year helper column used for partitioning must not leak into stored data."""
+        df = pd.DataFrame([_ohlcv_row("AAPL", datetime.date(2024, 1, 2))])
+        write_table(df, "ohlcv", tmp_path)
+        result = read_table("ohlcv", tmp_path)
+        assert "year" not in result.columns
+        assert "_year" not in result.columns
+
+
+# ---------------------------------------------------------------------------
+# read_table — argument validation and empty-state handling
+# ---------------------------------------------------------------------------
+
+
+class TestReadTableValidation:
+    def test_unknown_table_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="Unknown table"):
+            read_table("nonexistent", tmp_path)
+
+    def test_missing_table_dir_returns_empty(self, tmp_path):
+        result = read_table("ohlcv", tmp_path)
+        assert isinstance(result, pd.DataFrame)
+        assert result.empty
+
+    def test_missing_single_file_returns_empty(self, tmp_path):
+        (tmp_path / "macro").mkdir()  # dir exists but no data.parquet
+        result = read_table("macro", tmp_path)
+        assert result.empty
+
+    def test_no_matching_partitions_returns_empty(self, tmp_path):
+        # Write 2022 data, then query for 2024 only
+        df = pd.DataFrame([_ohlcv_row("AAPL", datetime.date(2022, 6, 1))])
+        write_table(df, "ohlcv", tmp_path)
+        result = read_table(
+            "ohlcv", tmp_path,
+            start_date=datetime.date(2024, 1, 1),
+        )
+        assert result.empty
+
+
+# ---------------------------------------------------------------------------
+# read_table — filters
+# ---------------------------------------------------------------------------
+
+
+class TestReadTableFilters:
+    @pytest.fixture()
+    def populated_ohlcv(self, tmp_path):
+        rows = [
+            _ohlcv_row("AAPL", datetime.date(2023, 12, 1)),
+            _ohlcv_row("AAPL", datetime.date(2024, 1, 15)),
+            _ohlcv_row("AAPL", datetime.date(2024, 3, 1)),
+            _ohlcv_row("MSFT", datetime.date(2024, 1, 15)),
+            _ohlcv_row("GOOGL", datetime.date(2024, 2, 1)),
+        ]
+        write_table(pd.DataFrame(rows), "ohlcv", tmp_path)
+        return tmp_path
+
+    def test_symbols_filter(self, populated_ohlcv):
+        result = read_table("ohlcv", populated_ohlcv, symbols=["AAPL"])
+        assert set(result["symbol"]) == {"AAPL"}
+        assert len(result) == 3
+
+    def test_symbols_filter_multiple(self, populated_ohlcv):
+        result = read_table("ohlcv", populated_ohlcv, symbols=["AAPL", "MSFT"])
+        assert set(result["symbol"]) == {"AAPL", "MSFT"}
+
+    def test_symbols_filter_empty_list_returns_empty(self, populated_ohlcv):
+        result = read_table("ohlcv", populated_ohlcv, symbols=[])
+        assert result.empty
+
+    def test_start_date_filter(self, populated_ohlcv):
+        result = read_table(
+            "ohlcv", populated_ohlcv,
+            start_date=datetime.date(2024, 1, 1),
+        )
+        dates = pd.to_datetime(result["period_start_date"]).dt.date
+        assert all(d >= datetime.date(2024, 1, 1) for d in dates)
+        assert len(result) == 4  # three 2024 AAPL + one MSFT + one GOOGL (5 total - 1 dec23)
+
+    def test_end_date_filter(self, populated_ohlcv):
+        result = read_table(
+            "ohlcv", populated_ohlcv,
+            end_date=datetime.date(2024, 1, 31),
+        )
+        dates = pd.to_datetime(result["period_start_date"]).dt.date
+        assert all(d <= datetime.date(2024, 1, 31) for d in dates)
+
+    def test_start_and_end_date_filter(self, populated_ohlcv):
+        result = read_table(
+            "ohlcv", populated_ohlcv,
+            start_date=datetime.date(2024, 1, 1),
+            end_date=datetime.date(2024, 1, 31),
+        )
+        dates = pd.to_datetime(result["period_start_date"]).dt.date
+        assert all(datetime.date(2024, 1, 1) <= d <= datetime.date(2024, 1, 31) for d in dates)
+
+    def test_date_filter_prunes_partitions(self, populated_ohlcv):
+        """Querying only 2024 should not load the 2023 partition at all."""
+        result = read_table(
+            "ohlcv", populated_ohlcv,
+            start_date=datetime.date(2024, 1, 1),
+            end_date=datetime.date(2024, 12, 31),
+        )
+        dates = pd.to_datetime(result["period_start_date"]).dt.date
+        assert all(d.year == 2024 for d in dates)
+
+    def test_columns_projection(self, populated_ohlcv):
+        result = read_table(
+            "ohlcv", populated_ohlcv,
+            columns=["symbol", "close", "period_start_date"],
+        )
+        assert set(result.columns) == {"symbol", "close", "period_start_date"}
+
+    @pytest.fixture()
+    def populated_macro(self, tmp_path):
+        rows = [
+            _macro_row("DFF", datetime.date(2024, 1, 2), 5.33),
+            _macro_row("DFF", datetime.date(2024, 1, 3), 5.33),
+            _macro_row("T10Y2Y", datetime.date(2024, 1, 2), 0.42),
+        ]
+        write_table(pd.DataFrame(rows), "macro", tmp_path)
+        return tmp_path
+
+    def test_series_ids_filter(self, populated_macro):
+        result = read_table("macro", populated_macro, series_ids=["DFF"])
+        assert set(result["series_id"]) == {"DFF"}
+        assert len(result) == 2
+
+    def test_series_ids_filter_empty_list_returns_empty(self, populated_macro):
+        result = read_table("macro", populated_macro, series_ids=[])
+        assert result.empty
+
+    def test_macro_date_filter(self, populated_macro):
+        result = read_table(
+            "macro", populated_macro,
+            start_date=datetime.date(2024, 1, 3),
+        )
+        assert len(result) == 1
+        assert result.iloc[0]["series_id"] == "DFF"
+
+
+# ---------------------------------------------------------------------------
+# Options table (uses multi-column dedup key)
+# ---------------------------------------------------------------------------
+
+
+class TestOptionsTable:
+    def test_roundtrip(self, tmp_path):
+        rows = [
+            _options_row("AAPL", datetime.date(2024, 1, 2), datetime.date(2024, 2, 16), 185.0, "call"),
+            _options_row("AAPL", datetime.date(2024, 1, 2), datetime.date(2024, 2, 16), 185.0, "put"),
+            _options_row("AAPL", datetime.date(2024, 1, 2), datetime.date(2024, 2, 16), 190.0, "call"),
+        ]
+        df = pd.DataFrame(rows)
+        n = write_table(df, "options", tmp_path)
+        assert n == 3
+        result = read_table("options", tmp_path)
+        assert len(result) == 3
+
+    def test_dedup_on_full_contract_key(self, tmp_path):
+        row = _options_row("AAPL", datetime.date(2024, 1, 2), datetime.date(2024, 2, 16), 185.0, "call")
+        df = pd.DataFrame([row])
+        write_table(df, "options", tmp_path)
+        n = write_table(df, "options", tmp_path)
+        assert n == 0
+        result = read_table("options", tmp_path)
+        assert len(result) == 1
+
+    def test_same_strike_different_type_are_distinct(self, tmp_path):
+        call = _options_row("AAPL", datetime.date(2024, 1, 2), datetime.date(2024, 2, 16), 185.0, "call")
+        put = _options_row("AAPL", datetime.date(2024, 1, 2), datetime.date(2024, 2, 16), 185.0, "put")
+        df = pd.DataFrame([call, put])
+        n = write_table(df, "options", tmp_path)
+        assert n == 2


### PR DESCRIPTION
## Summary

- Adds `schema.py`: `ReportTimeMarker`/`DataSource` enums, PyArrow schemas for all 5 data types, and per-table `DEDUP_KEYS` / `SORT_KEYS` / `PARTITION_COLS` maps
- Adds `storage.py`: `write_table()` and `read_table()` utilities with Hive-style `year=` partitioning for high-volume tables (ohlcv, fundamentals, options) and single-file storage for small tables (indices, macro)
- All writes are atomic (`.tmp` → rename) and idempotent (deduplication on table-specific keys)
- 93 new tests covering schema validation, round-trips, deduplication, partition pruning, and all filter types

## Bitemporal fields added to every table

| Field | Type | Purpose |
|---|---|---|
| `period_start_date` | date | Start of the business period this row covers |
| `period_end_date` | date | End of the business period |
| `report_date` | date | Date the data was publicly available |
| `report_time_marker` | str | `pre-market` / `during-hours` / `post-market` |
| `source` | str | `yfinance` / `fred` / `ishares` |
| `collected_at` | timestamp(UTC) | When our pipeline collected this row |

## Storage layout

```
data/ohlcv/year=2024/data.parquet       ← partitioned (ohlcv, fundamentals, options)
data/macro/data.parquet                 ← single file (indices, macro)
```

## No pipeline changes

The existing fetch modules are untouched. Issues #39–#42 will migrate each pipeline to write through these utilities.

Closes #38

## Test plan

- [x] `pytest tests/test_schema.py tests/test_storage.py` — 93 new tests, all pass
- [x] Full suite (`pytest`) — 241 tests, all pass