### PR TITLE
Add dependency resilience and source failure handling

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -87,6 +87,20 @@ sources:
     indices:       3
 
 # ---------------------------------------------------------------------------
+# resilience: retry and failure-quarantine settings
+# ---------------------------------------------------------------------------
+resilience:
+  # Maximum number of attempts per fetch call (1 = no retry)
+  retry_attempts: 3
+
+  # Exponential back-off bounds in seconds
+  retry_min_wait: 2
+  retry_max_wait: 60
+
+  # Consecutive failures before a ticker is quarantined (skipped by the pipeline)
+  quarantine_threshold: 5
+
+# ---------------------------------------------------------------------------
 # health: maximum acceptable age (days) for each data type
 # ---------------------------------------------------------------------------
 health:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
   "fredapi>=0.5",
   "python-dotenv>=1.0",
   "pyyaml>=6.0",
+  "tenacity>=8.2",
 ]
 
 [project.scripts]
@@ -27,6 +28,7 @@ market-data-fetch-macro         = "market_data.fetch_macro:main"
 market-data-fetch-fundamentals  = "market_data.fetch_fundamentals:main"
 market-data-fetch-options       = "market_data.fetch_options:main"
 market-data-health              = "market_data.health:main"
+market-data-smoke-test          = "market_data.smoke_test:main"
 
 [project.optional-dependencies]
 dev = [

--- a/src/market_data/fetch.py
+++ b/src/market_data/fetch.py
@@ -21,6 +21,7 @@ import pandas as pd
 import yfinance as yf
 
 from market_data.config import cfg as _cfg
+from market_data.resilience import yf_retry
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -81,6 +82,7 @@ def _ticker_path(symbol: str, data_dir: Path) -> Path:
 # Public API
 # ---------------------------------------------------------------------------
 
+@yf_retry
 def fetch_history(symbol: str, years: int = DEFAULT_HISTORY_YEARS) -> pd.DataFrame:
     """
     Download `years` of daily OHLCV history for `symbol`.
@@ -100,6 +102,7 @@ def fetch_history(symbol: str, years: int = DEFAULT_HISTORY_YEARS) -> pd.DataFra
     return _normalize(raw, symbol)
 
 
+@yf_retry
 def fetch_incremental(symbol: str, since: date) -> pd.DataFrame:
     """
     Download daily OHLCV data for `symbol` from `since` onward.

--- a/src/market_data/fetch_fundamentals.py
+++ b/src/market_data/fetch_fundamentals.py
@@ -47,6 +47,7 @@ import pandas as pd
 import yfinance as yf
 
 from market_data.config import cfg as _cfg
+from market_data.resilience import yf_retry
 
 logger = logging.getLogger(__name__)
 
@@ -136,17 +137,23 @@ def save_fundamentals(symbol: str, record: dict, fund_dir: Path) -> int:
 # Fetch
 # ---------------------------------------------------------------------------
 
+@yf_retry
+def _fetch_ticker_info(symbol: str) -> dict:
+    """Fetch raw yfinance .info dict for *symbol*. Raises on network failure."""
+    return yf.Ticker(symbol).info
+
+
 def fetch_fundamentals(symbol: str) -> dict | None:
     """
     Pull the fundamentals snapshot for `symbol` via yfinance .info.
 
     Returns a dict ready to pass to save_fundamentals(), or None if the ticker
-    returned no usable data.
+    returned no usable data (e.g. ETF, delisted, or no market cap reported).
+
+    Raises on transient network errors after retries are exhausted, so the
+    caller can distinguish a temporary outage from a permanently absent ticker.
     """
-    try:
-        info = yf.Ticker(symbol).info
-    except Exception:
-        return None
+    info = _fetch_ticker_info(symbol)
 
     # Require at least a market cap to consider the record valid
     if not info.get("marketCap"):

--- a/src/market_data/fetch_macro.py
+++ b/src/market_data/fetch_macro.py
@@ -47,6 +47,7 @@ from pathlib import Path
 import pandas as pd
 
 from market_data.config import cfg as _cfg
+from market_data.resilience import fred_retry
 
 logger = logging.getLogger(__name__)
 
@@ -166,6 +167,7 @@ def save_macro_series(series_id: str, new_df: pd.DataFrame, macro_dir: Path) -> 
 # Fetch
 # ---------------------------------------------------------------------------
 
+@fred_retry
 def fetch_series(
     series_id: str,
     start: str,

--- a/src/market_data/fetch_options.py
+++ b/src/market_data/fetch_options.py
@@ -60,6 +60,7 @@ import pandas as pd
 import yfinance as yf
 
 from market_data.config import cfg as _cfg
+from market_data.resilience import yf_retry
 
 logger = logging.getLogger(__name__)
 
@@ -131,19 +132,31 @@ def get_etf_symbols(onboarded: set[str]) -> list[str]:
 # Fetch
 # ---------------------------------------------------------------------------
 
+@yf_retry
+def _get_expiry_dates(ticker: yf.Ticker) -> tuple:
+    """Return available option expiry dates for *ticker*. Raises on network failure."""
+    return ticker.options
+
+
+@yf_retry
+def _get_option_chain(ticker: yf.Ticker, expiry_str: str):
+    """Fetch one option chain for *ticker* / *expiry_str*. Raises on network failure."""
+    return ticker.option_chain(expiry_str)
+
+
 def fetch_option_chain(symbol: str, max_expiries: int) -> pd.DataFrame:
     """
     Fetch the nearest `max_expiries` option chains for `symbol`.
 
     Returns a DataFrame with OPTIONS_COLS schema, or an empty DataFrame if
     no data is available.
+
+    Raises on transient network errors after retries are exhausted so the
+    caller can distinguish an outage from a ticker with no listed options.
     """
     ticker = yf.Ticker(symbol)
 
-    try:
-        expiry_dates = ticker.options  # tuple of expiry date strings
-    except Exception:
-        return pd.DataFrame(columns=OPTIONS_COLS)
+    expiry_dates = _get_expiry_dates(ticker)  # raises on network failure
 
     if not expiry_dates:
         return pd.DataFrame(columns=OPTIONS_COLS)
@@ -154,8 +167,10 @@ def fetch_option_chain(symbol: str, max_expiries: int) -> pd.DataFrame:
 
     for expiry_str in selected:
         try:
-            chain = ticker.option_chain(expiry_str)
+            chain = _get_option_chain(ticker, expiry_str)
         except Exception:
+            # One expiry failing does not block the rest — skip and continue
+            logger.warning("%s  could not fetch expiry %s — skipping", symbol, expiry_str)
             continue
 
         for side, df_raw in (("call", chain.calls), ("put", chain.puts)):

--- a/src/market_data/fetch_tickers.py
+++ b/src/market_data/fetch_tickers.py
@@ -23,6 +23,8 @@ from pathlib import Path
 import pandas as pd
 import requests
 
+from market_data.resilience import requests_retry
+
 logger = logging.getLogger(__name__)
 
 # iShares ETF holdings CSV endpoints (no auth required)
@@ -61,6 +63,7 @@ HEADERS = {
 }
 
 
+@requests_retry
 def fetch_etf_holdings(url: str) -> pd.DataFrame:
     """Download an iShares ETF holdings CSV and return the raw DataFrame."""
     logger.info("Downloading ETF holdings from %s...", url[:60])

--- a/src/market_data/orchestrator.py
+++ b/src/market_data/orchestrator.py
@@ -54,6 +54,7 @@ import pandas as pd
 from market_data.config import cfg as _cfg
 from market_data.fetch import DEFAULT_HISTORY_YEARS, fetch_history, fetch_incremental, save_ticker_data
 from market_data import metrics
+from market_data import resilience
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +87,7 @@ def load_state() -> dict:
             "last_ticker_refresh": raw.get("last_ticker_refresh"),
             "last_fundamentals_run": raw.get("last_fundamentals_run"),
             "options_cycle": raw.get("options_cycle", []),
+            "fetch_failures": raw.get("fetch_failures", {}),
         }
     return {
         "onboarded": [],
@@ -93,6 +95,7 @@ def load_state() -> dict:
         "last_ticker_refresh": None,
         "last_fundamentals_run": None,
         "options_cycle": [],
+        "fetch_failures": {},
     }
 
 
@@ -293,6 +296,7 @@ def step_onboard(
     pending: list[str],
     batch_size: int,
     onboarded: set[str],
+    state: dict,
 ) -> tuple[set[str], set[str]]:
     """
     Fetch full history for the next `batch_size` pending tickers.
@@ -323,14 +327,17 @@ def step_onboard(
             if df.empty:
                 logger.info("%s  no data (skipping)", prefix)
                 metrics.record_symbol_result(symbol, success=False, reason="no data")
+                resilience.record_failure(state, symbol, "no data")
             else:
                 added = save_ticker_data(symbol, df, DATA_DIR)
                 newly_onboarded.add(symbol)
+                resilience.clear_failure(state, symbol)
                 logger.info("%s  %d rows saved", prefix, added)
                 metrics.record_symbol_result(symbol, success=True, rows_written=added)
         except Exception as exc:
             logger.error("%s  ERROR: %s", prefix, exc, exc_info=True)
             failed.add(symbol)
+            resilience.record_failure(state, symbol, str(exc))
             metrics.record_symbol_result(symbol, success=False, reason=str(exc))
 
         time.sleep(SLEEP_BETWEEN_CALLS)
@@ -350,6 +357,7 @@ def step_onboard(
 def step_update(
     to_update: list[str],
     since: date,
+    state: dict,
 ) -> dict[str, int]:
     """
     Fetch incremental data for all `to_update` tickers since `since`.
@@ -379,9 +387,11 @@ def step_update(
                 results[symbol] = added
                 total_rows += added
                 metrics.record_symbol_result(symbol, success=True, rows_written=added)
+            resilience.clear_failure(state, symbol)
         except Exception as exc:
             logger.error("%s  ERROR: %s", prefix, exc, exc_info=True)
             results[symbol] = 0
+            resilience.record_failure(state, symbol, str(exc))
             metrics.record_symbol_result(symbol, success=False, reason=str(exc))
 
         time.sleep(SLEEP_BETWEEN_CALLS)
@@ -433,23 +443,36 @@ def run(batch_size: int, skip_update: bool, run_merge: bool, run_indices: bool =
     )
     logger.info("Last ticker refresh: %s", state.get("last_ticker_refresh") or "never")
 
+    # --- Report quarantined tickers up front ---
+    quarantined = resilience.quarantined_symbols(state)
+    if quarantined:
+        logger.warning(
+            "Quarantined tickers (%d) — skipping until failures are resolved: %s",
+            len(quarantined),
+            ", ".join(quarantined[:20]) + (" …" if len(quarantined) > 20 else ""),
+        )
+
     # --- 1a. Priority-onboard ETFs (outside the normal batch limit) ---
     # ETFs sit at the bottom of tickers.csv (NaN market_value sorts last) so
     # without this pre-pass they would wait until all ~1,500 stock tickers are
     # onboarded.  There are at most 19 ETFs, so this adds <2 minutes once.
     from market_data.etf_config import ALL_ETFS  # noqa: PLC0415
-    etf_pending = [t for t in ALL_ETFS if t not in onboarded and t in set(all_tickers)]
+    quarantined_set = set(quarantined)
+    etf_pending = [
+        t for t in ALL_ETFS
+        if t not in onboarded and t in set(all_tickers) and t not in quarantined_set
+    ]
     etf_newly_onboarded: set[str] = set()
     if etf_pending:
         logger.info("ETFs pending onboarding: %s", etf_pending)
         etf_newly_onboarded, _ = step_onboard(
-            etf_pending, batch_size=len(etf_pending), onboarded=onboarded
+            etf_pending, batch_size=len(etf_pending), onboarded=onboarded, state=state
         )
         onboarded |= etf_newly_onboarded
 
     # --- 1b. Onboard new stock tickers (batch-limited, ETFs excluded) ---
-    non_etf_pending = [t for t in pending if t not in set(ALL_ETFS)]
-    newly_onboarded, _failed = step_onboard(non_etf_pending, batch_size, onboarded)
+    non_etf_pending = [t for t in pending if t not in set(ALL_ETFS) and t not in quarantined_set]
+    newly_onboarded, _failed = step_onboard(non_etf_pending, batch_size, onboarded, state=state)
     onboarded |= newly_onboarded
 
     all_newly_onboarded = etf_newly_onboarded | newly_onboarded
@@ -458,8 +481,11 @@ def run(batch_size: int, skip_update: bool, run_merge: bool, run_indices: bool =
     if not skip_update and last_run:
         # Update tickers that were already onboarded before this run
         # (newly onboarded ones just got full history; no need to update them)
-        to_update = [t for t in all_tickers if t in onboarded and t not in all_newly_onboarded]
-        step_update(to_update, since=last_run)
+        to_update = [
+            t for t in all_tickers
+            if t in onboarded and t not in all_newly_onboarded and t not in quarantined_set
+        ]
+        step_update(to_update, since=last_run, state=state)
     elif not skip_update and not last_run:
         logger.info("UPDATE   skipped — no previous run date in state.json")
 
@@ -498,16 +524,25 @@ def run(batch_size: int, skip_update: bool, run_merge: bool, run_indices: bool =
         state["last_fundamentals_run"] = str(today)
     if updated_options_cycle is not None:
         state["options_cycle"] = sorted(updated_options_cycle)
+    # fetch_failures was updated in-place by step_onboard / step_update
     save_state(state)
 
     # --- 8. Summary ---
     remaining = len([t for t in all_tickers if t not in onboarded])
+    final_quarantined = resilience.quarantined_symbols(state)
     logger.info(
-        "Done.  Onboarded: %d/%d  |  Remaining: %d",
+        "Done.  Onboarded: %d/%d  |  Remaining: %d  |  Quarantined: %d",
         len(onboarded),
         len(all_tickers),
         remaining,
+        len(final_quarantined),
     )
+    if final_quarantined:
+        logger.warning(
+            "Quarantined (%d) — run with --show-failures for details: %s",
+            len(final_quarantined),
+            ", ".join(final_quarantined[:10]) + (" …" if len(final_quarantined) > 10 else ""),
+        )
     if remaining > 0 and batch_size > 0:
         eta = (remaining + batch_size - 1) // batch_size
         logger.info(

--- a/src/market_data/resilience.py
+++ b/src/market_data/resilience.py
@@ -1,0 +1,182 @@
+"""
+resilience.py
+-------------
+Retry decorators and per-ticker failure-tracking helpers for the market_data
+pipeline.
+
+Retry behaviour
+---------------
+Three decorator factories share the same exponential-backoff policy, differing
+only in their label for log messages:
+
+  yf_retry        — yfinance calls (``yf.Ticker(…).history``, ``.info``, etc.)
+  fred_retry      — FRED API calls (``fredapi.Fred.get_series``)
+  requests_retry  — raw ``requests`` calls (iShares CSV download)
+
+All decorators retry on transient network failures only (timeouts, connection
+resets, HTTP 429/5xx) and re-raise after exhausting attempts.  Requires
+``tenacity>=8.2``; if tenacity is not installed the decorators are no-ops
+(existing behaviour is preserved and a DEBUG message is emitted).
+
+Failure tracking
+----------------
+The orchestrator calls these helpers to maintain a ``fetch_failures`` dict
+inside the pipeline ``state`` dict (which is persisted to ``state.json``):
+
+  record_failure(state, symbol, reason)  — increment consecutive-failure count
+  clear_failure(state, symbol)           — reset count on a successful fetch
+  is_quarantined(state, symbol)          — True when count >= threshold
+  quarantined_symbols(state)             — sorted list of quarantined symbols
+
+The quarantine threshold defaults to 5 and is configurable via
+``resilience.quarantine_threshold`` in ``config.yaml``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable, TypeVar
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+F = TypeVar("F", bound=Callable)
+
+# ---------------------------------------------------------------------------
+# Transient / permanent exception classification
+# ---------------------------------------------------------------------------
+
+#: HTTP status codes that warrant a retry (rate-limit, server errors)
+TRANSIENT_HTTP_CODES: frozenset[int] = frozenset({429, 500, 502, 503, 504})
+
+
+def _is_transient(exc: BaseException) -> bool:
+    """Return True if *exc* is a transient, retryable network failure."""
+    if isinstance(exc, (requests.Timeout, requests.ConnectionError)):
+        return True
+    if isinstance(exc, requests.HTTPError):
+        code = exc.response.status_code if exc.response is not None else None
+        return code in TRANSIENT_HTTP_CODES
+    # Walk the exception chain — yfinance and fredapi wrap requests errors
+    cause = exc.__cause__ or exc.__context__
+    if cause is not None and cause is not exc:
+        return _is_transient(cause)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Retry decorator factory
+# ---------------------------------------------------------------------------
+
+def _make_retry_decorator(label: str) -> Callable[[F], F]:
+    """
+    Build a tenacity retry decorator for *label* data source.
+
+    Reads ``resilience.retry_attempts``, ``resilience.retry_min_wait``, and
+    ``resilience.retry_max_wait`` from config (with sensible defaults).
+
+    Falls back to an identity decorator if tenacity is not installed.
+    """
+    try:
+        from tenacity import (  # noqa: PLC0415
+            retry,
+            retry_if_exception,
+            stop_after_attempt,
+            wait_exponential,
+            before_sleep_log,
+        )
+        from market_data.config import cfg as _cfg  # noqa: PLC0415
+
+        attempts: int = _cfg.get("resilience.retry_attempts", 3)
+        min_wait: int = _cfg.get("resilience.retry_min_wait", 2)
+        max_wait: int = _cfg.get("resilience.retry_max_wait", 60)
+
+        return retry(  # type: ignore[return-value]
+            retry=retry_if_exception(_is_transient),
+            wait=wait_exponential(multiplier=1, min=min_wait, max=max_wait),
+            stop=stop_after_attempt(attempts),
+            before_sleep=before_sleep_log(logger, logging.WARNING),
+            reraise=True,
+        )
+    except ImportError:
+        logger.debug("tenacity not installed; %s retry is disabled", label)
+
+        def _identity(func: F) -> F:
+            return func
+
+        return _identity  # type: ignore[return-value]
+
+
+def yf_retry(func: F) -> F:
+    """Retry a yfinance call on transient network failures."""
+    return _make_retry_decorator("yfinance")(func)
+
+
+def fred_retry(func: F) -> F:
+    """Retry a FRED API call on transient network failures."""
+    return _make_retry_decorator("FRED")(func)
+
+
+def requests_retry(func: F) -> F:
+    """Retry a raw requests call on transient network failures."""
+    return _make_retry_decorator("requests")(func)
+
+
+# ---------------------------------------------------------------------------
+# Failure tracking helpers
+# ---------------------------------------------------------------------------
+
+def _failures(state: dict) -> dict:
+    """Return the ``fetch_failures`` sub-dict from *state*, creating it if absent."""
+    if "fetch_failures" not in state:
+        state["fetch_failures"] = {}
+    return state["fetch_failures"]
+
+
+def record_failure(state: dict, symbol: str, reason: str) -> None:
+    """
+    Increment the consecutive-failure counter for *symbol* in *state*.
+
+    Stores the date of the latest failure and a truncated reason string.
+    """
+    from datetime import date  # noqa: PLC0415
+
+    failures = _failures(state)
+    entry: dict = failures.get(symbol, {"count": 0})
+    entry["count"] = entry.get("count", 0) + 1
+    entry["last_failure"] = str(date.today())
+    entry["last_reason"] = str(reason)[:200]
+    failures[symbol] = entry
+
+
+def clear_failure(state: dict, symbol: str) -> None:
+    """Remove the failure record for *symbol* after a successful fetch."""
+    _failures(state).pop(symbol, None)
+
+
+def _quarantine_threshold(state: dict | None = None) -> int:
+    """Return the configured quarantine threshold (default: 5)."""
+    try:
+        from market_data.config import cfg as _cfg  # noqa: PLC0415
+        return int(_cfg.get("resilience.quarantine_threshold", 5))
+    except Exception:  # noqa: BLE001
+        return 5
+
+
+def is_quarantined(state: dict, symbol: str) -> bool:
+    """Return True if *symbol* has reached or exceeded the quarantine threshold."""
+    entry = _failures(state).get(symbol)
+    if entry is None:
+        return False
+    return entry.get("count", 0) >= _quarantine_threshold(state)
+
+
+def quarantined_symbols(state: dict) -> list[str]:
+    """Return a sorted list of all currently quarantined symbols."""
+    threshold = _quarantine_threshold(state)
+    return sorted(
+        sym
+        for sym, entry in _failures(state).items()
+        if entry.get("count", 0) >= threshold
+    )

--- a/src/market_data/smoke_test.py
+++ b/src/market_data/smoke_test.py
@@ -1,0 +1,154 @@
+"""
+smoke_test.py
+-------------
+Lightweight connectivity check for all external data sources used by the
+market_data pipeline.
+
+Each check makes exactly one minimal request to its source and reports whether
+the source is reachable.  Run this before a full pipeline run to surface
+network or credential problems early.
+
+Sources checked
+---------------
+  yfinance (Yahoo Finance)   — 1 day of AAPL OHLCV via yfinance
+  FRED (Federal Reserve)     — 1 observation of DFF via fredapi
+  iShares IWM holdings CSV   — HTTP GET (header-only) of the IWM CSV endpoint
+  iShares IVV holdings CSV   — HTTP GET (header-only) of the IVV CSV endpoint
+
+Exit codes
+----------
+  0  — all sources reachable
+  1  — one or more sources unreachable
+
+Usage
+-----
+    market-data-smoke-test
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from datetime import date, timedelta
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Individual source checks
+# ---------------------------------------------------------------------------
+
+def check_yfinance() -> tuple[bool, str]:
+    """Fetch 1 day of AAPL data via yfinance."""
+    try:
+        import yfinance as yf  # noqa: PLC0415
+        df = yf.Ticker("AAPL").history(period="1d")
+        if df.empty:
+            return False, "returned empty DataFrame"
+        return True, f"{len(df)} row(s) returned"
+    except Exception as exc:
+        return False, str(exc)
+
+
+def check_fred() -> tuple[bool, str]:
+    """Fetch 1 observation of DFF (Fed Funds Rate) via fredapi."""
+    try:
+        from market_data.fetch_macro import _load_api_key  # noqa: PLC0415
+        api_key = _load_api_key()
+    except RuntimeError as exc:
+        return False, str(exc)
+
+    try:
+        import fredapi  # noqa: PLC0415
+        fred = fredapi.Fred(api_key=api_key)
+        start = str(date.today() - timedelta(days=30))
+        result = fred.get_series("DFF", observation_start=start)
+        if result is None or result.empty:
+            return False, "no data returned"
+        return True, f"{len(result)} observation(s)"
+    except Exception as exc:
+        return False, str(exc)
+
+
+def check_ishares_iwm() -> tuple[bool, str]:
+    """HEAD request to the iShares IWM holdings CSV endpoint."""
+    try:
+        import requests  # noqa: PLC0415
+        from market_data.fetch_tickers import IWM_CSV_URL, HEADERS  # noqa: PLC0415
+        resp = requests.get(IWM_CSV_URL, headers=HEADERS, timeout=15, stream=True)
+        resp.raise_for_status()
+        return True, f"HTTP {resp.status_code}"
+    except Exception as exc:
+        return False, str(exc)
+
+
+def check_ishares_ivv() -> tuple[bool, str]:
+    """HEAD request to the iShares IVV holdings CSV endpoint."""
+    try:
+        import requests  # noqa: PLC0415
+        from market_data.fetch_tickers import IVV_CSV_URL, HEADERS  # noqa: PLC0415
+        resp = requests.get(IVV_CSV_URL, headers=HEADERS, timeout=15, stream=True)
+        resp.raise_for_status()
+        return True, f"HTTP {resp.status_code}"
+    except Exception as exc:
+        return False, str(exc)
+
+
+# ---------------------------------------------------------------------------
+# Source registry
+# ---------------------------------------------------------------------------
+
+#: (display_name, check_function)
+SOURCES: list[tuple[str, object]] = [
+    ("yfinance (Yahoo Finance)", check_yfinance),
+    ("FRED (Federal Reserve API)", check_fred),
+    ("iShares IWM holdings CSV", check_ishares_iwm),
+    ("iShares IVV holdings CSV", check_ishares_ivv),
+]
+
+
+# ---------------------------------------------------------------------------
+# Core run logic
+# ---------------------------------------------------------------------------
+
+def run() -> bool:
+    """
+    Run all source checks and log results.
+
+    Returns True if every source is reachable, False otherwise.
+    """
+    all_ok = True
+    for name, check_fn in SOURCES:
+        ok, detail = check_fn()  # type: ignore[operator]
+        status = "OK  " if ok else "FAIL"
+        logger.info("  %-38s [%s]  %s", name, status, detail)
+        if not ok:
+            all_ok = False
+    return all_ok
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    from market_data.logging_config import setup_logging  # noqa: PLC0415
+    setup_logging()
+
+    logger.info("market_data smoke test  —  %s", date.today())
+    logger.info("Checking data sources...")
+
+    ok = run()
+
+    if ok:
+        logger.info("All sources reachable. Safe to run the full pipeline.")
+    else:
+        logger.warning(
+            "One or more sources unreachable. "
+            "Resolve the issues above before running market-data-run."
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_resilience.py
+++ b/tests/test_resilience.py
@@ -1,0 +1,223 @@
+"""
+Tests for resilience.py: exception classification, failure tracking, and
+quarantine helpers.
+
+Network calls and tenacity's actual retry behaviour are not exercised here
+(that would require a live server).  Instead we verify:
+
+  - _is_transient() correctly classifies various exceptions
+  - record_failure / clear_failure / is_quarantined / quarantined_symbols
+    maintain correct state-dict entries
+  - yf_retry / fred_retry / requests_retry return a callable (identity or
+    wrapped) without raising at decoration time
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from market_data import resilience
+from market_data.resilience import (
+    _is_transient,
+    clear_failure,
+    is_quarantined,
+    quarantined_symbols,
+    record_failure,
+)
+
+
+# ---------------------------------------------------------------------------
+# _is_transient()
+# ---------------------------------------------------------------------------
+
+class TestIsTransient:
+    def test_timeout_is_transient(self):
+        assert _is_transient(requests.Timeout())
+
+    def test_connection_error_is_transient(self):
+        assert _is_transient(requests.ConnectionError())
+
+    def test_http_429_is_transient(self):
+        resp = MagicMock()
+        resp.status_code = 429
+        exc = requests.HTTPError(response=resp)
+        assert _is_transient(exc)
+
+    def test_http_500_is_transient(self):
+        resp = MagicMock()
+        resp.status_code = 500
+        exc = requests.HTTPError(response=resp)
+        assert _is_transient(exc)
+
+    def test_http_503_is_transient(self):
+        resp = MagicMock()
+        resp.status_code = 503
+        exc = requests.HTTPError(response=resp)
+        assert _is_transient(exc)
+
+    def test_http_404_is_not_transient(self):
+        resp = MagicMock()
+        resp.status_code = 404
+        exc = requests.HTTPError(response=resp)
+        assert not _is_transient(exc)
+
+    def test_http_400_is_not_transient(self):
+        resp = MagicMock()
+        resp.status_code = 400
+        exc = requests.HTTPError(response=resp)
+        assert not _is_transient(exc)
+
+    def test_value_error_is_not_transient(self):
+        assert not _is_transient(ValueError("bad series"))
+
+    def test_runtime_error_is_not_transient(self):
+        assert not _is_transient(RuntimeError("unexpected"))
+
+    def test_transient_via_exception_chain(self):
+        """_is_transient walks __cause__ to detect wrapped requests errors."""
+        outer = RuntimeError("yfinance wrapper")
+        outer.__cause__ = requests.Timeout()
+        assert _is_transient(outer)
+
+    def test_non_transient_chain(self):
+        """Exception chain with no transient cause is not transient."""
+        outer = RuntimeError("wrapper")
+        outer.__cause__ = ValueError("inner")
+        assert not _is_transient(outer)
+
+    def test_http_error_with_no_response_is_not_transient(self):
+        exc = requests.HTTPError(response=None)
+        assert not _is_transient(exc)
+
+
+# ---------------------------------------------------------------------------
+# record_failure / clear_failure / is_quarantined / quarantined_symbols
+# ---------------------------------------------------------------------------
+
+class TestFailureTracking:
+    def _state(self) -> dict:
+        return {"fetch_failures": {}}
+
+    def test_record_failure_increments_count(self):
+        state = self._state()
+        record_failure(state, "AAPL", "timeout")
+        assert state["fetch_failures"]["AAPL"]["count"] == 1
+
+    def test_record_failure_twice_increments(self):
+        state = self._state()
+        record_failure(state, "AAPL", "timeout")
+        record_failure(state, "AAPL", "timeout")
+        assert state["fetch_failures"]["AAPL"]["count"] == 2
+
+    def test_record_failure_stores_reason(self):
+        state = self._state()
+        record_failure(state, "AAPL", "Connection reset")
+        assert state["fetch_failures"]["AAPL"]["last_reason"] == "Connection reset"
+
+    def test_record_failure_stores_date(self):
+        from datetime import date
+        state = self._state()
+        record_failure(state, "AAPL", "timeout")
+        assert state["fetch_failures"]["AAPL"]["last_failure"] == str(date.today())
+
+    def test_record_failure_truncates_long_reason(self):
+        state = self._state()
+        long_reason = "x" * 300
+        record_failure(state, "AAPL", long_reason)
+        assert len(state["fetch_failures"]["AAPL"]["last_reason"]) <= 200
+
+    def test_record_failure_creates_fetch_failures_key_if_absent(self):
+        state: dict = {}
+        record_failure(state, "AAPL", "err")
+        assert "fetch_failures" in state
+
+    def test_clear_failure_removes_entry(self):
+        state = self._state()
+        record_failure(state, "AAPL", "timeout")
+        clear_failure(state, "AAPL")
+        assert "AAPL" not in state["fetch_failures"]
+
+    def test_clear_failure_no_op_when_not_present(self):
+        state = self._state()
+        clear_failure(state, "AAPL")  # should not raise
+
+    def test_is_quarantined_false_when_below_threshold(self, monkeypatch):
+        monkeypatch.setattr(resilience, "_quarantine_threshold", lambda _=None: 5)
+        state = self._state()
+        for _ in range(4):
+            record_failure(state, "AAPL", "err")
+        assert not is_quarantined(state, "AAPL")
+
+    def test_is_quarantined_true_at_threshold(self, monkeypatch):
+        monkeypatch.setattr(resilience, "_quarantine_threshold", lambda _=None: 5)
+        state = self._state()
+        for _ in range(5):
+            record_failure(state, "AAPL", "err")
+        assert is_quarantined(state, "AAPL")
+
+    def test_is_quarantined_false_when_not_present(self):
+        state = self._state()
+        assert not is_quarantined(state, "AAPL")
+
+    def test_quarantined_symbols_returns_sorted_list(self, monkeypatch):
+        monkeypatch.setattr(resilience, "_quarantine_threshold", lambda _=None: 3)
+        state = self._state()
+        for sym in ["ZZZZ", "AAAA", "MMMM"]:
+            for _ in range(3):
+                record_failure(state, sym, "err")
+        # One ticker below threshold
+        record_failure(state, "BBBB", "err")
+
+        result = quarantined_symbols(state)
+        assert result == ["AAAA", "MMMM", "ZZZZ"]
+        assert "BBBB" not in result
+
+    def test_quarantined_symbols_empty_when_none_quarantined(self):
+        state = self._state()
+        assert quarantined_symbols(state) == []
+
+    def test_clear_failure_removes_from_quarantine(self, monkeypatch):
+        monkeypatch.setattr(resilience, "_quarantine_threshold", lambda _=None: 3)
+        state = self._state()
+        for _ in range(3):
+            record_failure(state, "AAPL", "err")
+        assert is_quarantined(state, "AAPL")
+        clear_failure(state, "AAPL")
+        assert not is_quarantined(state, "AAPL")
+
+
+# ---------------------------------------------------------------------------
+# Decorator smoke test — verify the decorators are callable at decoration time
+# ---------------------------------------------------------------------------
+
+class TestRetryDecorators:
+    def test_yf_retry_returns_callable(self):
+        @resilience.yf_retry
+        def dummy():
+            return 42
+
+        assert callable(dummy)
+
+    def test_fred_retry_returns_callable(self):
+        @resilience.fred_retry
+        def dummy():
+            return 42
+
+        assert callable(dummy)
+
+    def test_requests_retry_returns_callable(self):
+        @resilience.requests_retry
+        def dummy():
+            return 42
+
+        assert callable(dummy)
+
+    def test_decorated_function_executes_normally(self):
+        @resilience.yf_retry
+        def add(a, b):
+            return a + b
+
+        assert add(2, 3) == 5

--- a/tests/test_resilience.py
+++ b/tests/test_resilience.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-import pytest
 import requests
 
 from market_data import resilience

--- a/tests/test_smoke_test.py
+++ b/tests/test_smoke_test.py
@@ -8,8 +8,6 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from market_data import smoke_test
 from market_data.smoke_test import (
     check_fred,

--- a/tests/test_smoke_test.py
+++ b/tests/test_smoke_test.py
@@ -1,0 +1,172 @@
+"""
+Tests for smoke_test.py.
+
+All external network calls are mocked — no live connections required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from market_data import smoke_test
+from market_data.smoke_test import (
+    check_fred,
+    check_ishares_ivv,
+    check_ishares_iwm,
+    check_yfinance,
+    run,
+)
+
+
+# ---------------------------------------------------------------------------
+# check_yfinance
+# ---------------------------------------------------------------------------
+
+class TestCheckYfinance:
+    def test_returns_ok_when_data_present(self):
+        import pandas as pd
+        mock_df = pd.DataFrame({"Close": [150.0]})
+        mock_ticker = MagicMock()
+        mock_ticker.history.return_value = mock_df
+
+        with patch("yfinance.Ticker", return_value=mock_ticker):
+            ok, detail = check_yfinance()
+
+        assert ok is True
+        assert "1 row" in detail
+
+    def test_returns_fail_when_empty_df(self):
+        import pandas as pd
+        mock_ticker = MagicMock()
+        mock_ticker.history.return_value = pd.DataFrame()
+
+        with patch("yfinance.Ticker", return_value=mock_ticker):
+            ok, detail = check_yfinance()
+
+        assert ok is False
+        assert "empty" in detail.lower()
+
+    def test_returns_fail_on_exception(self):
+        with patch("yfinance.Ticker", side_effect=ConnectionError("unreachable")):
+            ok, detail = check_yfinance()
+
+        assert ok is False
+        assert detail != ""
+
+
+# ---------------------------------------------------------------------------
+# check_fred
+# ---------------------------------------------------------------------------
+
+class TestCheckFred:
+    def test_returns_fail_when_api_key_missing(self):
+        with patch(
+            "market_data.fetch_macro._load_api_key",
+            side_effect=RuntimeError("FRED_API_KEY is not set"),
+        ):
+            ok, detail = check_fred()
+
+        assert ok is False
+        assert "FRED_API_KEY" in detail
+
+    def test_returns_ok_when_data_present(self):
+        import pandas as pd
+        mock_series = pd.Series([5.33], index=["2026-04-01"])
+
+        with patch("market_data.fetch_macro._load_api_key", return_value="testkey"):
+            mock_fred = MagicMock()
+            mock_fred.get_series.return_value = mock_series
+            with patch("fredapi.Fred", return_value=mock_fred):
+                ok, detail = check_fred()
+
+        assert ok is True
+        assert "1 observation" in detail
+
+    def test_returns_fail_when_empty_series(self):
+        import pandas as pd
+
+        with patch("market_data.fetch_macro._load_api_key", return_value="testkey"):
+            mock_fred = MagicMock()
+            mock_fred.get_series.return_value = pd.Series([], dtype=float)
+            with patch("fredapi.Fred", return_value=mock_fred):
+                ok, detail = check_fred()
+
+        assert ok is False
+
+    def test_returns_fail_on_connection_error(self):
+        with patch("market_data.fetch_macro._load_api_key", return_value="testkey"):
+            with patch("fredapi.Fred", side_effect=ConnectionError("no route")):
+                ok, detail = check_fred()
+
+        assert ok is False
+        assert detail != ""
+
+
+# ---------------------------------------------------------------------------
+# check_ishares_iwm / check_ishares_ivv
+# ---------------------------------------------------------------------------
+
+class TestCheckIshares:
+    def _mock_ok_response(self):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.raise_for_status.return_value = None
+        return resp
+
+    def test_iwm_ok(self):
+        with patch("requests.get", return_value=self._mock_ok_response()):
+            ok, detail = check_ishares_iwm()
+        assert ok is True
+        assert "200" in detail
+
+    def test_ivv_ok(self):
+        with patch("requests.get", return_value=self._mock_ok_response()):
+            ok, detail = check_ishares_ivv()
+        assert ok is True
+        assert "200" in detail
+
+    def test_iwm_fail_on_exception(self):
+        import requests as req
+        with patch("requests.get", side_effect=req.ConnectionError("timeout")):
+            ok, detail = check_ishares_iwm()
+        assert ok is False
+
+    def test_ivv_fail_on_http_error(self):
+        import requests as req
+        resp = MagicMock()
+        resp.status_code = 503
+        with patch(
+            "requests.get",
+            side_effect=req.HTTPError(response=resp),
+        ):
+            ok, detail = check_ishares_ivv()
+        assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# run()
+# ---------------------------------------------------------------------------
+
+class TestRun:
+    """Tests for run() — patch SOURCES directly since the list holds references."""
+
+    def _sources(self, results: list[tuple[bool, str]]) -> list[tuple[str, object]]:
+        return [(f"source_{i}", lambda ok=ok, detail=detail: (ok, detail))
+                for i, (ok, detail) in enumerate(results)]
+
+    def test_returns_true_when_all_ok(self):
+        sources = self._sources([(True, "ok"), (True, "ok"), (True, "ok"), (True, "ok")])
+        with patch.object(smoke_test, "SOURCES", sources):
+            assert run() is True
+
+    def test_returns_false_when_any_fail(self):
+        sources = self._sources([(True, "ok"), (False, "key missing"), (True, "ok"), (True, "ok")])
+        with patch.object(smoke_test, "SOURCES", sources):
+            assert run() is False
+
+    def test_returns_false_when_all_fail(self):
+        sources = self._sources([(False, "err"), (False, "err"), (False, "err"), (False, "err")])
+        with patch.object(smoke_test, "SOURCES", sources):
+            assert run() is False


### PR DESCRIPTION
## Summary

Closes #28.

- **Retry with exponential backoff** — new `resilience.py` module wraps yfinance, FRED, and iShares requests with tenacity-backed retry decorators (`yf_retry`, `fred_retry`, `requests_retry`). Transient errors (timeout, connection reset, HTTP 429/5xx — including those wrapped inside yfinance/fredapi exception chains) are retried up to 3 times with 2–60s backoff. Non-transient errors (HTTP 404, bad credentials, etc.) surface immediately.

- **Failure tracking and quarantine** — the orchestrator now maintains a `fetch_failures` dict in `state.json`. Consecutive failures per ticker are counted; tickers that reach the threshold (default: 5) are quarantined — skipped from both onboarding and incremental updates until a successful fetch resets the counter. Quarantined tickers are surfaced in the run banner and summary line.

- **Smoke-test command** — `market-data-smoke-test` hits each source with one minimal request and reports reachability before a full run. Exits 0 if all sources are up, 1 otherwise.

- **Config** — new `resilience:` section in `config.yaml` exposes `retry_attempts`, `retry_min_wait`, `retry_max_wait`, and `quarantine_threshold`.

## What changed

| File | Change |
|------|--------|
| `resilience.py` | New — retry decorators + failure-tracking helpers |
| `smoke_test.py` | New — `market-data-smoke-test` CLI |
| `fetch.py` | `@yf_retry` on `fetch_history`, `fetch_incremental` |
| `fetch_fundamentals.py` | Extracted `_fetch_ticker_info` with `@yf_retry`; exceptions now propagate instead of being silently swallowed |
| `fetch_macro.py` | `@fred_retry` on `fetch_series` |
| `fetch_options.py` | `@yf_retry` on `_get_expiry_dates`, `_get_option_chain` helpers |
| `fetch_tickers.py` | `@requests_retry` on `fetch_etf_holdings` |
| `orchestrator.py` | `fetch_failures` in state, quarantine filtering in onboard/update queues, summary reporting |
| `pyproject.toml` | `tenacity>=8.2` dependency, `market-data-smoke-test` entry point |
| `config.yaml` | `resilience:` section |

## Tests

44 new tests in `test_resilience.py` (exception classification, failure tracking, decorator smoke tests) and `test_smoke_test.py` (all four source checks + `run()`). Full suite: **264 passed**.

## Reviewer notes

- The `fetch_fundamentals._fetch_ticker_info` refactor changes observable behaviour: previously `fetch_fundamentals()` returned `None` for both "no market cap" and network errors; it now raises on network errors so the outer `run()` loop correctly increments `failed` instead of `skipped`. The logged output and metrics are more accurate as a result.
- Quarantine is conservative — it only skips a ticker after 5 **consecutive** failures. A single successful fetch resets the counter entirely.
- `tenacity` is a new required dependency (not optional) since the retry policy is important to pipeline correctness.