### PR TITLE
Add conventional branch naming rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,3 +80,5 @@ State (onboarded tickers, last run date, options cycle position) is persisted to
 ## Git
 
 Do not attribute commits or PRs to Claude. No `Co-Authored-By` lines, no mention of Claude in commit messages or PR bodies.
+
+Name branches using conventional prefixes: `feature/`, `fix/`, `hotfix/`, `release/`, or `chore/`, followed by a concise lowercase hyphenated description (e.g. `feature/add-login`, `fix/issue-123-header-bug`). No random words.


### PR DESCRIPTION
## What changed

Added a branch naming convention rule to the Git section of `CLAUDE.md`.

## Why

Branches were being named with random words (e.g. `claude/blissful-feynman`) rather than descriptive names. This rule enforces conventional prefixes (`feature/`, `fix/`, `hotfix/`, `release/`, `chore/`) with concise hyphenated descriptions, making branch purpose immediately clear from the name.

## Reviewer notes

One sentence addition — no code changes.