### PR TITLE
fix: read_table returns typed empty DataFrame and warns on old-format files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented here.
 
 ---
 
+## [0.5.3] — 2026-04-15 ([#PR](https://github.com/michaelk95/market_data/pull/NEW))
+
+### Fixed
+- `read_table` now returns an empty DataFrame with correct schema columns (instead of
+  a bare `pd.DataFrame()` with zero columns) on all no-data paths, preventing
+  `KeyError` when callers access specific columns on the result.
+- `read_table` emits a `WARNING` log when a partitioned table directory contains flat
+  `.parquet` files but no `year=YYYY` partitions, signalling that the migration script
+  has not been run.
+
+---
+
 ## [0.5.2] — 2026-04-16 ([#46](https://github.com/michaelk95/market_data/pull/46))
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented here.
 
 ---
 
-## [0.5.3] — 2026-04-15 ([#PR](https://github.com/michaelk95/market_data/pull/NEW))
+## [0.5.3] — 2026-04-15 ([#50](https://github.com/michaelk95/market_data/pull/50))
 
 ### Fixed
 - `read_table` now returns an empty DataFrame with correct schema columns (instead of

--- a/src/market_data/storage.py
+++ b/src/market_data/storage.py
@@ -29,6 +29,7 @@ read_table(table_name, data_dir, *, start_date, end_date,
 from __future__ import annotations
 
 import datetime
+import logging
 from pathlib import Path
 
 import pandas as pd
@@ -40,6 +41,8 @@ from .schema import (
     TABLE_SCHEMAS,
     validate_bitemporal_columns,
 )
+
+logger = logging.getLogger(__name__)
 
 __all__ = ["write_table", "read_table"]
 
@@ -147,19 +150,29 @@ def read_table(
 
     table_dir = data_dir / table_name
     if not table_dir.exists():
-        return pd.DataFrame()
+        return _empty_df(table_name, columns)
 
     partition_cols = PARTITION_COLS[table_name]
 
     if not partition_cols:
         path = table_dir / "data.parquet"
         if not path.exists():
-            return pd.DataFrame()
+            return _empty_df(table_name, columns)
         df = pd.read_parquet(path, columns=columns)
     else:
         files = _get_partition_files(table_dir, start_date, end_date)
         if not files:
-            return pd.DataFrame()
+            # Warn if flat (old-format) files exist but no year=* partitions — a
+            # likely sign that market-data-migrate-fundamentals hasn't been run.
+            flat_files = [p for p in table_dir.iterdir() if p.suffix == ".parquet" and p.is_file()]
+            if flat_files:
+                logger.warning(
+                    "read_table('%s'): directory %s contains %d flat .parquet file(s) "
+                    "but no year=YYYY partitions. Run the migration script to convert "
+                    "old-format files to the bitemporal layout.",
+                    table_name, table_dir, len(flat_files),
+                )
+            return _empty_df(table_name, columns)
         df = pd.concat(
             [pd.read_parquet(f, columns=columns) for f in files],
             ignore_index=True,
@@ -180,6 +193,15 @@ def read_table(
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
+
+def _empty_df(table_name: str, columns: list[str] | None) -> pd.DataFrame:
+    """Return an empty DataFrame whose columns match the table schema (or the
+    requested *columns* projection).  This avoids KeyError when callers do
+    ``df[["col1", "col2"]]`` on a no-data result."""
+    schema_cols = TABLE_SCHEMAS[table_name].names
+    cols = columns if columns is not None else schema_cols
+    return pd.DataFrame(columns=cols)
 
 
 def _merge_write(

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -262,10 +262,21 @@ class TestReadTableValidation:
         assert isinstance(result, pd.DataFrame)
         assert result.empty
 
+    def test_missing_table_dir_returns_schema_columns(self, tmp_path):
+        result = read_table("ohlcv", tmp_path)
+        assert "symbol" in result.columns
+        assert "period_start_date" in result.columns
+
     def test_missing_single_file_returns_empty(self, tmp_path):
         (tmp_path / "macro").mkdir()  # dir exists but no data.parquet
         result = read_table("macro", tmp_path)
         assert result.empty
+
+    def test_missing_single_file_returns_schema_columns(self, tmp_path):
+        (tmp_path / "macro").mkdir()
+        result = read_table("macro", tmp_path)
+        assert "series_id" in result.columns
+        assert "period_start_date" in result.columns
 
     def test_no_matching_partitions_returns_empty(self, tmp_path):
         # Write 2022 data, then query for 2024 only
@@ -276,6 +287,30 @@ class TestReadTableValidation:
             start_date=datetime.date(2024, 1, 1),
         )
         assert result.empty
+
+    def test_no_matching_partitions_returns_schema_columns(self, tmp_path):
+        df = pd.DataFrame([_ohlcv_row("AAPL", datetime.date(2022, 6, 1))])
+        write_table(df, "ohlcv", tmp_path)
+        result = read_table("ohlcv", tmp_path, start_date=datetime.date(2024, 1, 1))
+        assert "symbol" in result.columns
+        assert "period_start_date" in result.columns
+
+    def test_flat_files_without_partitions_warns(self, tmp_path, caplog):
+        """Old-format flat .parquet files should trigger a migration warning."""
+        import logging
+        fund_dir = tmp_path / "fundamentals"
+        fund_dir.mkdir()
+        # Simulate old per-ticker file (old schema, no year= partitions)
+        pd.DataFrame({"symbol": ["AAPL"]}).to_parquet(fund_dir / "AAPL.parquet")
+        with caplog.at_level(logging.WARNING, logger="market_data.storage"):
+            result = read_table("fundamentals", tmp_path)
+        assert result.empty
+        assert "symbol" in result.columns
+        assert any("flat .parquet" in msg for msg in caplog.messages)
+
+    def test_columns_projection_on_empty_returns_requested_columns(self, tmp_path):
+        result = read_table("ohlcv", tmp_path, columns=["symbol", "close"])
+        assert list(result.columns) == ["symbol", "close"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #39 (verification bug noted in latest comment).

## Summary

- `read_table` was returning `pd.DataFrame()` (zero columns) on all no-data paths. Any column access like `df[["symbol", "report_date"]]` on the result raised `KeyError`.
- Now returns an empty DataFrame whose columns match the table's schema (or the requested `columns` projection), so downstream code gets 0 rows with the right schema instead of a crash.
- Added a `WARNING` log when a partitioned table directory exists with flat `.parquet` files but no `year=YYYY` partitions — the signal that `market-data-migrate-fundamentals` hasn't been run yet.

## Test plan

- [ ] `pytest tests/test_storage.py` — all 44 tests pass
- [ ] `ruff check src/market_data/storage.py tests/test_storage.py` — clean
- [ ] New tests cover: schema columns on missing dir, missing single file, no matching partitions, columns projection on empty, and the flat-files warning path