### PR TITLE
feat: macro revisions tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to this project will be documented here.
 
 ---
 
+## [0.6.0] — 2026-04-16 ([#42](https://github.com/michaelk95/market_data/pull/42))
+
+### Added
+- `storage.read_macro_as_of(series_ids, as_of_date, data_dir)` — point-in-time query
+  returning the vintage of each (series_id, period) that was current on `as_of_date`.
+  Primary primitive for look-ahead-bias-free backtest queries.
+- `storage.read_macro_revisions(series_id, period_start_date, data_dir)` — returns all
+  vintages of one observation ordered by `report_date`, with computed columns
+  `revision_rank`, `value_change`, and `value_change_pct`.
+- `fetch_macro.SERIES_LOOKBACK_DAYS` — per-series incremental lookback map.
+  GDPC1 and GDP use a 400-day window to catch annual benchmark revisions (released
+  each July); all other series keep the 7-day default.
+- `fetch_macro._detect_revisions()` — detects and logs new vintages for already-seen
+  observation periods (`[macro] Revision detected: …`).
+- `fetch_macro._recompute_revision_ranks()` — after each incremental write, recomputes
+  `revision_rank` across the full stored series so ranks are always correct.
+
+### Changed
+- `schema.py`: `MACRO_SCHEMA` gains `revision_rank` (`int32`) and `release_name`
+  (`string`, nullable). `SORT_KEYS["macro"]` now includes `report_date` so stored rows
+  are ordered by `(period_start_date, series_id, report_date)`.
+- `fetch_macro.fetch_series_vintages()`: populates `revision_rank` (ordinal within the
+  fetched slice) and `release_name` (static mapping for all default FRED series).
+- `fetch_macro.update_series()`: uses `SERIES_LOOKBACK_DAYS` for the incremental window;
+  calls `_detect_revisions` before writing and `_recompute_revision_ranks` after.
+
+---
+
 ## [0.5.4] — 2026-04-15 ([#41](https://github.com/michaelk95/market_data/pull/41))
 
 ### Added

--- a/src/market_data/fetch_macro.py
+++ b/src/market_data/fetch_macro.py
@@ -201,7 +201,10 @@ def fetch_series_vintages(
     df["period_start_date"] = pd.to_datetime(df["date"]).dt.date
     df["period_end_date"] = df["period_start_date"]
     df["report_date"] = pd.to_datetime(df["realtime_start"]).dt.date
-    df["valid_to_date"] = pd.to_datetime(df["realtime_end"]).dt.date
+    # Avoid pd.to_datetime here: it overflows on 9999-12-31 in pandas < 2.0
+    df["valid_to_date"] = df["realtime_end"].apply(
+        lambda d: d if isinstance(d, date) else pd.Timestamp(d).date()
+    )
     df["series_id"] = series_id
     df["report_time_marker"] = ReportTimeMarker.POST_MARKET
     df["source"] = DataSource.FRED

--- a/src/market_data/fetch_macro.py
+++ b/src/market_data/fetch_macro.py
@@ -9,6 +9,10 @@ the supersession date (``valid_to_date = FRED realtime_end``; ``9999-12-31``
 for the currently-active value), enabling point-in-time queries that are free
 of look-ahead bias from data revisions (e.g., GDP advance vs. final estimates).
 
+``revision_rank`` (1 = advance, 2 = second estimate, …) is stored on every row
+and kept consistent across the whole series after each incremental update via
+``_recompute_revision_ranks``.
+
 Series collected by default
 ----------------------------
 Daily
@@ -89,8 +93,32 @@ DEFAULT_SERIES: list[str] = list(
     ).keys()
 )
 
+# Incremental lookback window per series.  GDP annual revisions (released each
+# July) can silently revise observations from years prior, so quarterly GDP
+# series use a much wider window than the daily/monthly default.
+SERIES_LOOKBACK_DAYS: dict[str, int] = {
+    "GDPC1": 400,
+    "GDP":   400,
+}
+_DEFAULT_LOOKBACK_DAYS = 7
+
+# Static FRED release names for default series (best-effort; None for unknowns)
+_SERIES_RELEASE_NAMES: dict[str, str] = {
+    "GDPC1":    "Gross Domestic Product",
+    "GDP":      "Gross Domestic Product",
+    "CPIAUCSL": "Consumer Price Index for All Urban Consumers",
+    "CPILFESL": "Consumer Price Index for All Urban Consumers: All Items Less Food and Energy",
+    "PCEPI":    "Personal Income and Outlays",
+    "PCEPILFE": "Personal Income and Outlays",
+    "UNRATE":   "Employment Situation",
+    "PAYEMS":   "Employment Situation",
+    "DFF":      "H.15 Selected Interest Rates",
+    "T10Y2Y":   "H.15 Selected Interest Rates",
+}
+
 _EMPTY_COLS: list[str] = [
     "series_id", "value", "valid_to_date",
+    "revision_rank", "release_name",
     "period_start_date", "period_end_date",
     "report_date", "report_time_marker", "source", "collected_at",
 ]
@@ -140,6 +168,14 @@ def fetch_series_vintages(
     (``report_date``) and supersession date (``valid_to_date``), enabling
     point-in-time queries that are free of look-ahead bias from revisions.
 
+    Also populates:
+    - ``revision_rank``: ordinal position within the revision chain for each
+      observation period (1 = advance estimate, 2 = second, …).  The rank is
+      computed across the returned slice only; ``update_series`` recomputes it
+      across the full stored series after each write.
+    - ``release_name``: human-readable FRED release name (static mapping for
+      default series; ``None`` for others).
+
     Returns a DataFrame ready for ``storage.write_table("macro", ...)``.
     Returns an empty DataFrame (with correct columns) if no data is available.
     """
@@ -172,7 +208,111 @@ def fetch_series_vintages(
     df["collected_at"] = datetime.now(timezone.utc)
     df["value"] = df["value"].astype(float)
 
+    # revision_rank: ordinal within each (series, period) group ordered by report_date.
+    # Computed over this fetch slice; _recompute_revision_ranks corrects it later for
+    # incremental runs that only cover a lookback window.
+    df["revision_rank"] = (
+        df.sort_values("report_date")
+          .groupby("period_start_date", sort=False)
+          .cumcount()
+        + 1
+    )
+
+    df["release_name"] = _SERIES_RELEASE_NAMES.get(series_id)
+
     return df[_EMPTY_COLS].reset_index(drop=True)
+
+
+# ---------------------------------------------------------------------------
+# Revision-rank maintenance
+# ---------------------------------------------------------------------------
+
+def _recompute_revision_ranks(series_id: str, data_dir: Path) -> None:
+    """Recompute ``revision_rank`` for *series_id* across the entire stored dataset.
+
+    Called after ``write_table`` to ensure ranks are correct even when
+    incremental fetches (which only cover a lookback window) add new vintages
+    to observations that already exist in storage.
+
+    Operates directly on the parquet file with an atomic tmp-rename write.
+    """
+    path = data_dir / "macro" / "data.parquet"
+    if not path.exists():
+        return
+
+    df = pd.read_parquet(path)
+    if "series_id" not in df.columns:
+        return
+
+    mask = df["series_id"] == series_id
+    if not mask.any():
+        return
+
+    series_df = df.loc[mask].copy()
+    # Sort so cumcount is assigned in chronological vintage order
+    series_df = series_df.sort_values(["period_start_date", "report_date"])
+    series_df["revision_rank"] = (
+        series_df.groupby("period_start_date", sort=False).cumcount() + 1
+    )
+    # Align by index back into the full DataFrame
+    df.loc[mask, "revision_rank"] = series_df["revision_rank"]
+
+    tmp = path.with_name("data.tmp.parquet")
+    df.to_parquet(tmp, index=False)
+    tmp.replace(path)
+
+
+# ---------------------------------------------------------------------------
+# Revision detection
+# ---------------------------------------------------------------------------
+
+def _detect_revisions(
+    series_id: str,
+    existing: pd.DataFrame,
+    new_df: pd.DataFrame,
+) -> int:
+    """Detect new vintages that revise an already-seen observation period.
+
+    Logs one INFO line per revision and returns the total count.  A "revision"
+    is a row whose ``(period_start_date, report_date)`` key is not in *existing*
+    but whose ``period_start_date`` IS — meaning the observation was already
+    released and this is a subsequent estimate.
+
+    Parameters
+    ----------
+    series_id:
+        FRED series ID (used in log messages only).
+    existing:
+        Rows already in storage for this series (may be empty).
+    new_df:
+        Rows returned from the current fetch.
+    """
+    if existing.empty or new_df.empty:
+        return 0
+
+    existing_keys = set(
+        zip(
+            pd.to_datetime(existing["period_start_date"]).dt.date,
+            pd.to_datetime(existing["report_date"]).dt.date,
+        )
+    )
+    existing_periods = set(pd.to_datetime(existing["period_start_date"]).dt.date)
+
+    count = 0
+    for _, row in new_df.iterrows():
+        period = pd.Timestamp(row["period_start_date"]).date()
+        report = pd.Timestamp(row["report_date"]).date()
+        if (period, report) not in existing_keys and period in existing_periods:
+            logger.info(
+                "[macro] Revision detected: %s period=%s new_value=%.4f (report_date=%s)",
+                series_id,
+                period,
+                float(row["value"]),
+                report,
+            )
+            count += 1
+
+    return count
 
 
 # ---------------------------------------------------------------------------
@@ -184,8 +324,9 @@ def update_series(series_id: str, api_key: str, start: str, data_dir: Path) -> i
     Bootstrap or incrementally update a single FRED series with vintage data.
 
     On first run: pulls all vintages from *start* to today.
-    On subsequent runs: pulls from (max report_date - 7 days) to today,
-    catching late-released revisions.
+    On subsequent runs: pulls from (max report_date − lookback) to today.
+    The lookback window is series-specific (see ``SERIES_LOOKBACK_DAYS``);
+    quarterly GDP uses 400 days to catch annual benchmark revisions.
 
     Returns the number of new rows added.
     """
@@ -196,9 +337,10 @@ def update_series(series_id: str, api_key: str, start: str, data_dir: Path) -> i
         action = f"bootstrap from {start}"
     else:
         latest_report = pd.to_datetime(existing["report_date"]).dt.date.max()
-        lookback = latest_report - timedelta(days=7)
+        lookback_days = SERIES_LOOKBACK_DAYS.get(series_id, _DEFAULT_LOOKBACK_DAYS)
+        lookback = latest_report - timedelta(days=lookback_days)
         realtime_start = str(lookback)
-        action = f"incremental since {lookback}"
+        action = f"incremental since {lookback} ({lookback_days}d window)"
 
     df = fetch_series_vintages(series_id, realtime_start=realtime_start, api_key=api_key)
 
@@ -206,8 +348,15 @@ def update_series(series_id: str, api_key: str, start: str, data_dir: Path) -> i
         logger.info("%s  no data  (%s)", series_id, action)
         return 0
 
+    n_revisions = _detect_revisions(series_id, existing, df)
     added = write_table(df, "macro", data_dir)
-    logger.info("%s  +%d rows  (%s)", series_id, added, action)
+    if added > 0:
+        _recompute_revision_ranks(series_id, data_dir)
+
+    logger.info(
+        "%s  +%d rows  %d revisions  (%s)",
+        series_id, added, n_revisions, action,
+    )
     return added
 
 

--- a/src/market_data/schema.py
+++ b/src/market_data/schema.py
@@ -112,6 +112,8 @@ MACRO_SCHEMA = pa.schema([
     pa.field("series_id", pa.string()),
     pa.field("value", pa.float64()),
     pa.field("valid_to_date", pa.date32()),  # FRED realtime_end; 9999-12-31 = currently active
+    pa.field("revision_rank", pa.int32()),   # 1 = advance estimate, 2 = second, … (within period)
+    pa.field("release_name", pa.string()),   # FRED release name, nullable
     *_BITEMPORAL_FIELDS,
 ])
 
@@ -158,7 +160,7 @@ SORT_KEYS: dict[str, list[str]] = {
     "ohlcv": ["period_start_date", "symbol"],
     "indices": ["period_start_date", "symbol"],
     "fundamentals": ["period_start_date", "symbol"],
-    "macro": ["period_start_date", "series_id"],
+    "macro": ["period_start_date", "series_id", "report_date"],
     "options": ["period_start_date", "symbol", "expiry", "strike", "option_type"],
     "analyst_estimates": ["period_start_date", "symbol"],
 }

--- a/src/market_data/storage.py
+++ b/src/market_data/storage.py
@@ -44,7 +44,7 @@ from .schema import (
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["write_table", "read_table"]
+__all__ = ["write_table", "read_table", "read_macro_as_of", "read_macro_revisions"]
 
 # ---------------------------------------------------------------------------
 # Public API
@@ -188,6 +188,106 @@ def read_table(
     )
 
     return df.reset_index(drop=True)
+
+
+# ---------------------------------------------------------------------------
+# Macro-specific query helpers
+# ---------------------------------------------------------------------------
+
+_FAR_FUTURE = datetime.date(9999, 12, 31)
+
+
+def read_macro_as_of(
+    series_ids: list[str],
+    as_of_date: datetime.date,
+    data_dir: Path,
+) -> pd.DataFrame:
+    """Return the vintage of each (series_id, period) that was current on *as_of_date*.
+
+    A vintage is "current" on a given date when:
+
+    - ``report_date <= as_of_date``  — it had been released by then
+    - ``valid_to_date > as_of_date`` — it had not yet been superseded
+      OR ``valid_to_date == 9999-12-31`` — it is the currently-active value
+
+    This is the primary point-in-time query for the backtest engine: given any
+    historical date, reconstruct the information set available at that moment,
+    with no look-ahead bias from subsequent data revisions.
+
+    Parameters
+    ----------
+    series_ids:
+        FRED series IDs to query (e.g. ``["GDPC1", "UNRATE"]``).
+    as_of_date:
+        The historical date to query as of.
+    data_dir:
+        Root data directory.
+
+    Returns
+    -------
+    pd.DataFrame
+        Rows from the macro table matching the point-in-time filter.
+        Empty DataFrame if no data is available.
+    """
+    df = read_table("macro", data_dir, series_ids=series_ids)
+    if df.empty:
+        return df
+
+    report_date = pd.to_datetime(df["report_date"]).dt.date
+    valid_to_date = pd.to_datetime(df["valid_to_date"]).dt.date
+
+    mask = (
+        (report_date <= as_of_date)
+        & ((valid_to_date > as_of_date) | (valid_to_date == _FAR_FUTURE))
+    )
+    return df[mask].reset_index(drop=True)
+
+
+def read_macro_revisions(
+    series_id: str,
+    period_start_date: datetime.date,
+    data_dir: Path,
+) -> pd.DataFrame:
+    """Return all vintages of a single macro observation, ordered by report_date.
+
+    Adds three computed columns to help trace the revision chain:
+
+    - ``revision_rank``     — 1-based ordinal (1 = first/advance estimate, …)
+    - ``value_change``      — absolute change from the previous vintage (NaN for first)
+    - ``value_change_pct``  — percent change from the previous vintage (NaN for first)
+
+    Parameters
+    ----------
+    series_id:
+        FRED series ID (e.g. ``"GDPC1"``).
+    period_start_date:
+        Start date of the observation period to inspect
+        (e.g. ``datetime.date(2019, 10, 1)`` for GDP Q4 2019).
+    data_dir:
+        Root data directory.
+
+    Returns
+    -------
+    pd.DataFrame
+        All vintages for the given observation, sorted by ``report_date``,
+        with ``revision_rank``, ``value_change``, ``value_change_pct`` appended.
+        Empty DataFrame if no data is found.
+    """
+    df = read_table("macro", data_dir, series_ids=[series_id])
+    if df.empty:
+        return df
+
+    obs_dates = pd.to_datetime(df["period_start_date"]).dt.date
+    df = df[obs_dates == period_start_date].copy()
+    if df.empty:
+        return df
+
+    df = df.sort_values("report_date").reset_index(drop=True)
+    df["revision_rank"] = range(1, len(df) + 1)
+    df["value_change"] = df["value"].diff()
+    df["value_change_pct"] = df["value"].pct_change() * 100
+
+    return df
 
 
 # ---------------------------------------------------------------------------

--- a/src/market_data/storage.py
+++ b/src/market_data/storage.py
@@ -233,8 +233,10 @@ def read_macro_as_of(
     if df.empty:
         return df
 
-    report_date = pd.to_datetime(df["report_date"]).dt.date
-    valid_to_date = pd.to_datetime(df["valid_to_date"]).dt.date
+    # date32 parquet columns return as object dtype with Python date objects.
+    # Avoid pd.to_datetime: it overflows on 9999-12-31 in pandas < 2.0.
+    report_date = df["report_date"]
+    valid_to_date = df["valid_to_date"]
 
     mask = (
         (report_date <= as_of_date)

--- a/tests/test_fetch_macro.py
+++ b/tests/test_fetch_macro.py
@@ -2,12 +2,21 @@
 from __future__ import annotations
 
 import datetime
+import logging
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
 
-from market_data.fetch_macro import DEFAULT_START, fetch_series_vintages, update_series
+from market_data.fetch_macro import (
+    DEFAULT_START,
+    SERIES_LOOKBACK_DAYS,
+    _DEFAULT_LOOKBACK_DAYS,
+    _detect_revisions,
+    fetch_series_vintages,
+    update_series,
+)
 from market_data.schema import DataSource, ReportTimeMarker
+from market_data.storage import write_table
 
 
 # ---------------------------------------------------------------------------
@@ -46,6 +55,23 @@ def _make_fred_mock(df: pd.DataFrame) -> MagicMock:
     fred = MagicMock()
     fred.get_series_all_releases.return_value = df
     return fred
+
+
+def _seed_row(series_id: str, period: datetime.date, report_date: datetime.date) -> dict:
+    """Return a minimal valid macro row dict for seeding storage."""
+    return {
+        "series_id": series_id,
+        "value": 19.1,
+        "valid_to_date": datetime.date(9999, 12, 31),
+        "revision_rank": 1,
+        "release_name": None,
+        "period_start_date": period,
+        "period_end_date": period,
+        "report_date": report_date,
+        "report_time_marker": ReportTimeMarker.POST_MARKET,
+        "source": DataSource.FRED,
+        "collected_at": pd.Timestamp("2024-01-01", tz="UTC"),
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -114,6 +140,31 @@ class TestFetchSeriesVintages:
         assert result.empty
         assert "series_id" in result.columns
 
+    def test_revision_rank_column_present(self):
+        result = self._call()
+        assert "revision_rank" in result.columns
+
+    def test_revision_rank_values(self):
+        """Q4 2019 appears twice → ranks 1,2; Q3 2019 once → rank 1."""
+        result = self._call()
+        q4 = result[result["period_start_date"] == datetime.date(2019, 10, 1)].sort_values("report_date")
+        assert list(q4["revision_rank"]) == [1, 2]
+        q3 = result[result["period_start_date"] == datetime.date(2019, 7, 1)]
+        assert list(q3["revision_rank"]) == [1]
+
+    def test_release_name_column_present(self):
+        result = self._call()
+        assert "release_name" in result.columns
+
+    def test_release_name_populated_for_known_series(self):
+        result = self._call()
+        assert (result["release_name"] == "Gross Domestic Product").all()
+
+    def test_release_name_none_for_unknown_series(self):
+        with patch("fredapi.Fred", return_value=_make_fred_mock(_VINTAGE_DF)):
+            result = fetch_series_vintages("CUSTOM_XYZ", realtime_start="2020-01-01", api_key="test")
+        assert result["release_name"].isna().all()
+
 
 # ---------------------------------------------------------------------------
 # TestUpdateSeries
@@ -138,20 +189,26 @@ class TestUpdateSeries:
         assert result == 0
 
     def test_incremental_uses_latest_report_date_minus_7_days(self, tmp_path):
-        """Subsequent run keys off max(report_date) − 7 days."""
-        from market_data.storage import write_table
+        """Subsequent run for a non-GDP series keys off max(report_date) − 7 days."""
+        seed = pd.DataFrame([_seed_row("DFF", datetime.date(2020, 1, 1), datetime.date(2020, 3, 26))])
+        write_table(seed, "macro", tmp_path)
 
-        seed = pd.DataFrame([{
-            "series_id": "GDPC1",
-            "value": 19.1,
-            "valid_to_date": datetime.date(9999, 12, 31),
-            "period_start_date": datetime.date(2020, 1, 1),
-            "period_end_date": datetime.date(2020, 1, 1),
-            "report_date": datetime.date(2020, 3, 26),
-            "report_time_marker": ReportTimeMarker.POST_MARKET,
-            "source": DataSource.FRED,
-            "collected_at": pd.Timestamp("2020-03-26", tz="UTC"),
-        }])
+        captured: dict = {}
+
+        def fake_fetch(series_id, realtime_start, api_key):
+            captured["realtime_start"] = realtime_start
+            return pd.DataFrame()
+
+        with patch("market_data.fetch_macro.fetch_series_vintages", side_effect=fake_fetch):
+            update_series("DFF", api_key="test", start=DEFAULT_START, data_dir=tmp_path)
+
+        expected = str(datetime.date(2020, 3, 26) - datetime.timedelta(days=7))
+        assert captured["realtime_start"] == expected
+
+    def test_gdpc1_uses_400_day_lookback(self, tmp_path):
+        """GDPC1 uses a 400-day window to catch annual benchmark revisions."""
+        report_date = datetime.date(2024, 7, 1)
+        seed = pd.DataFrame([_seed_row("GDPC1", datetime.date(2024, 1, 1), report_date)])
         write_table(seed, "macro", tmp_path)
 
         captured: dict = {}
@@ -163,7 +220,26 @@ class TestUpdateSeries:
         with patch("market_data.fetch_macro.fetch_series_vintages", side_effect=fake_fetch):
             update_series("GDPC1", api_key="test", start=DEFAULT_START, data_dir=tmp_path)
 
-        expected = str(datetime.date(2020, 3, 26) - datetime.timedelta(days=7))
+        expected_days = SERIES_LOOKBACK_DAYS["GDPC1"]
+        expected = str(report_date - datetime.timedelta(days=expected_days))
+        assert captured["realtime_start"] == expected
+
+    def test_default_series_uses_7_day_lookback(self, tmp_path):
+        """Series not in SERIES_LOOKBACK_DAYS fall back to _DEFAULT_LOOKBACK_DAYS."""
+        report_date = datetime.date(2024, 7, 1)
+        seed = pd.DataFrame([_seed_row("CPIAUCSL", datetime.date(2024, 6, 1), report_date)])
+        write_table(seed, "macro", tmp_path)
+
+        captured: dict = {}
+
+        def fake_fetch(series_id, realtime_start, api_key):
+            captured["realtime_start"] = realtime_start
+            return pd.DataFrame()
+
+        with patch("market_data.fetch_macro.fetch_series_vintages", side_effect=fake_fetch):
+            update_series("CPIAUCSL", api_key="test", start=DEFAULT_START, data_dir=tmp_path)
+
+        expected = str(report_date - datetime.timedelta(days=_DEFAULT_LOOKBACK_DAYS))
         assert captured["realtime_start"] == expected
 
     def test_returns_zero_on_empty_response(self, tmp_path):
@@ -173,17 +249,7 @@ class TestUpdateSeries:
 
     def test_idempotent(self, tmp_path):
         """Writing the same data twice returns 0 on the second call."""
-        row = pd.DataFrame([{
-            "series_id": "DFF",
-            "value": 5.33,
-            "valid_to_date": datetime.date(9999, 12, 31),
-            "period_start_date": datetime.date(2024, 1, 2),
-            "period_end_date": datetime.date(2024, 1, 2),
-            "report_date": datetime.date(2024, 1, 2),
-            "report_time_marker": ReportTimeMarker.POST_MARKET,
-            "source": DataSource.FRED,
-            "collected_at": pd.Timestamp("2024-01-02", tz="UTC"),
-        }])
+        row = pd.DataFrame([_seed_row("DFF", datetime.date(2024, 1, 2), datetime.date(2024, 1, 2))])
 
         def fake_fetch(series_id, realtime_start, api_key):
             return row.copy()
@@ -194,3 +260,82 @@ class TestUpdateSeries:
 
         assert first == 1
         assert second == 0
+
+    def test_revision_detected_logging(self, tmp_path, caplog):
+        """A new vintage for an already-known observation period is logged as a revision."""
+        period = datetime.date(2019, 10, 1)
+        first_vintage = pd.DataFrame([_seed_row("GDPC1", period, datetime.date(2020, 1, 30))])
+        write_table(first_vintage, "macro", tmp_path)
+
+        second_vintage = pd.DataFrame([{
+            **_seed_row("GDPC1", period, datetime.date(2020, 3, 26)),
+            "value": 19.2,
+            "valid_to_date": datetime.date(9999, 12, 31),
+            "revision_rank": 2,
+        }])
+
+        with caplog.at_level(logging.INFO, logger="market_data.fetch_macro"):
+            with patch(
+                "market_data.fetch_macro.fetch_series_vintages",
+                return_value=second_vintage,
+            ):
+                update_series("GDPC1", api_key="test", start=DEFAULT_START, data_dir=tmp_path)
+
+        revision_logs = [r for r in caplog.records if "Revision detected" in r.message]
+        assert len(revision_logs) >= 1
+        assert "GDPC1" in revision_logs[0].message
+
+    def test_revision_rank_recomputed_after_incremental(self, tmp_path):
+        """After an incremental write adds a new vintage, stored ranks are corrected."""
+        period = datetime.date(2019, 10, 1)
+        first = pd.DataFrame([_seed_row("GDPC1", period, datetime.date(2020, 1, 30))])
+        write_table(first, "macro", tmp_path)
+
+        second = pd.DataFrame([{
+            **_seed_row("GDPC1", period, datetime.date(2020, 3, 26)),
+            "revision_rank": 99,  # deliberately wrong — should be fixed by recompute
+        }])
+
+        with patch("market_data.fetch_macro.fetch_series_vintages", return_value=second):
+            update_series("GDPC1", api_key="test", start=DEFAULT_START, data_dir=tmp_path)
+
+        stored = pd.read_parquet(tmp_path / "macro" / "data.parquet")
+        stored = stored[stored["series_id"] == "GDPC1"].sort_values("report_date")
+        assert list(stored["revision_rank"]) == [1, 2]
+
+
+# ---------------------------------------------------------------------------
+# TestDetectRevisions
+# ---------------------------------------------------------------------------
+
+
+class TestDetectRevisions:
+    """Unit tests for _detect_revisions()."""
+
+    def _make_df(self, period, report_date, value=19.0) -> pd.DataFrame:
+        return pd.DataFrame([_seed_row("GDPC1", period, report_date)])
+
+    def test_returns_zero_when_existing_empty(self):
+        new_df = self._make_df(datetime.date(2019, 10, 1), datetime.date(2020, 1, 30))
+        assert _detect_revisions("GDPC1", pd.DataFrame(), new_df) == 0
+
+    def test_returns_zero_when_new_empty(self):
+        existing = self._make_df(datetime.date(2019, 10, 1), datetime.date(2020, 1, 30))
+        assert _detect_revisions("GDPC1", existing, pd.DataFrame()) == 0
+
+    def test_detects_new_vintage_for_known_period(self):
+        existing = self._make_df(datetime.date(2019, 10, 1), datetime.date(2020, 1, 30))
+        new_df = self._make_df(datetime.date(2019, 10, 1), datetime.date(2020, 3, 26))
+        assert _detect_revisions("GDPC1", existing, new_df) == 1
+
+    def test_ignores_new_periods(self):
+        """A brand-new observation period is not a revision."""
+        existing = self._make_df(datetime.date(2019, 10, 1), datetime.date(2020, 1, 30))
+        new_df = self._make_df(datetime.date(2020, 1, 1), datetime.date(2020, 4, 29))
+        assert _detect_revisions("GDPC1", existing, new_df) == 0
+
+    def test_ignores_already_known_vintage(self):
+        """Re-fetching an already-stored (period, report_date) pair is not a revision."""
+        existing = self._make_df(datetime.date(2019, 10, 1), datetime.date(2020, 1, 30))
+        new_df = self._make_df(datetime.date(2019, 10, 1), datetime.date(2020, 1, 30))
+        assert _detect_revisions("GDPC1", existing, new_df) == 0

--- a/tests/test_storage_macro.py
+++ b/tests/test_storage_macro.py
@@ -1,0 +1,188 @@
+"""Tests for macro-specific storage query helpers: read_macro_as_of, read_macro_revisions."""
+from __future__ import annotations
+
+import datetime
+
+import pandas as pd
+import pytest
+
+from market_data.schema import DataSource, ReportTimeMarker
+from market_data.storage import read_macro_as_of, read_macro_revisions, write_table
+
+FAR_FUTURE = datetime.date(9999, 12, 31)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _vintage(
+    series_id: str,
+    period: datetime.date,
+    report_date: datetime.date,
+    valid_to_date: datetime.date,
+    value: float,
+    revision_rank: int = 1,
+) -> dict:
+    return {
+        "series_id": series_id,
+        "value": value,
+        "valid_to_date": valid_to_date,
+        "revision_rank": revision_rank,
+        "release_name": "Test Release",
+        "period_start_date": period,
+        "period_end_date": period,
+        "report_date": report_date,
+        "report_time_marker": ReportTimeMarker.POST_MARKET,
+        "source": DataSource.FRED,
+        "collected_at": pd.Timestamp("2024-01-01", tz="UTC"),
+    }
+
+
+Q4_2019 = datetime.date(2019, 10, 1)
+Q3_2019 = datetime.date(2019, 7, 1)
+
+ADVANCE   = datetime.date(2020, 1, 30)   # report_date for advance estimate
+SECOND    = datetime.date(2020, 3, 26)   # report_date for second estimate
+FINAL     = datetime.date(2020, 6, 25)   # report_date for final estimate
+
+ADVANCE_SUPERSEDED = datetime.date(2020, 3, 25)
+SECOND_SUPERSEDED  = datetime.date(2020, 6, 24)
+
+
+@pytest.fixture
+def macro_store(tmp_path):
+    """Seed three vintages of GDP Q4 2019 and one vintage of Q3 2019."""
+    rows = [
+        _vintage("GDPC1", Q4_2019, ADVANCE, ADVANCE_SUPERSEDED, 19.1, revision_rank=1),
+        _vintage("GDPC1", Q4_2019, SECOND,  SECOND_SUPERSEDED,  19.2, revision_rank=2),
+        _vintage("GDPC1", Q4_2019, FINAL,   FAR_FUTURE,          19.3, revision_rank=3),
+        _vintage("GDPC1", Q3_2019, ADVANCE, FAR_FUTURE,          18.9, revision_rank=1),
+    ]
+    write_table(pd.DataFrame(rows), "macro", tmp_path)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# TestReadMacroAsOf
+# ---------------------------------------------------------------------------
+
+
+class TestReadMacroAsOf:
+
+    def _q4_row(self, result: pd.DataFrame) -> pd.DataFrame:
+        return result[
+            pd.to_datetime(result["period_start_date"]).dt.date == Q4_2019
+        ]
+
+    def test_advance_estimate_on_release_date(self, macro_store):
+        """As of the day after advance release, the advance estimate is current."""
+        result = read_macro_as_of(["GDPC1"], datetime.date(2020, 2, 1), macro_store)
+        q4 = self._q4_row(result)
+        assert len(q4) == 1
+        assert float(q4.iloc[0]["value"]) == pytest.approx(19.1)
+
+    def test_second_estimate_after_supersession(self, macro_store):
+        """After the advance is superseded, the second estimate is current."""
+        result = read_macro_as_of(["GDPC1"], datetime.date(2020, 4, 1), macro_store)
+        q4 = self._q4_row(result)
+        assert len(q4) == 1
+        assert float(q4.iloc[0]["value"]) == pytest.approx(19.2)
+
+    def test_final_estimate_when_active(self, macro_store):
+        """The final estimate (valid_to_date=9999-12-31) is returned for recent as-of dates."""
+        result = read_macro_as_of(["GDPC1"], datetime.date(2026, 1, 1), macro_store)
+        q4 = self._q4_row(result)
+        assert len(q4) == 1
+        assert float(q4.iloc[0]["value"]) == pytest.approx(19.3)
+
+    def test_no_row_before_any_release(self, macro_store):
+        """As of before the advance release date, no row is visible."""
+        result = read_macro_as_of(["GDPC1"], datetime.date(2020, 1, 1), macro_store)
+        q4 = self._q4_row(result)
+        assert len(q4) == 0
+
+    def test_includes_q3_observation(self, macro_store):
+        """Q3 2019 has a single always-active vintage; it appears in any as-of after its release."""
+        result = read_macro_as_of(["GDPC1"], datetime.date(2020, 2, 1), macro_store)
+        q3 = result[pd.to_datetime(result["period_start_date"]).dt.date == Q3_2019]
+        assert len(q3) == 1
+        assert float(q3.iloc[0]["value"]) == pytest.approx(18.9)
+
+    def test_empty_for_missing_table(self, tmp_path):
+        """No data directory → empty DataFrame, no error."""
+        result = read_macro_as_of(["GDPC1"], datetime.date(2024, 1, 1), tmp_path)
+        assert result.empty
+
+    def test_empty_for_unknown_series(self, macro_store):
+        result = read_macro_as_of(["NOPE"], datetime.date(2024, 1, 1), macro_store)
+        assert result.empty
+
+    def test_filters_to_requested_series(self, tmp_path):
+        """Only the requested series_ids are returned."""
+        rows = [
+            _vintage("DFF", datetime.date(2024, 1, 2), datetime.date(2024, 1, 2), FAR_FUTURE, 5.33),
+            _vintage("UNRATE", datetime.date(2024, 1, 1), datetime.date(2024, 2, 2), FAR_FUTURE, 3.7),
+        ]
+        write_table(pd.DataFrame(rows), "macro", tmp_path)
+        result = read_macro_as_of(["DFF"], datetime.date(2024, 3, 1), tmp_path)
+        assert set(result["series_id"].unique()) == {"DFF"}
+
+
+# ---------------------------------------------------------------------------
+# TestReadMacroRevisions
+# ---------------------------------------------------------------------------
+
+
+class TestReadMacroRevisions:
+
+    def test_returns_all_three_vintages(self, macro_store):
+        result = read_macro_revisions("GDPC1", Q4_2019, macro_store)
+        assert len(result) == 3
+
+    def test_sorted_by_report_date(self, macro_store):
+        result = read_macro_revisions("GDPC1", Q4_2019, macro_store)
+        dates = list(pd.to_datetime(result["report_date"]).dt.date)
+        assert dates == sorted(dates)
+
+    def test_revision_rank_sequence(self, macro_store):
+        result = read_macro_revisions("GDPC1", Q4_2019, macro_store)
+        assert list(result["revision_rank"]) == [1, 2, 3]
+
+    def test_value_change_first_row_is_nan(self, macro_store):
+        result = read_macro_revisions("GDPC1", Q4_2019, macro_store)
+        assert pd.isna(result.iloc[0]["value_change"])
+
+    def test_value_change_subsequent_rows(self, macro_store):
+        result = read_macro_revisions("GDPC1", Q4_2019, macro_store)
+        assert result.iloc[1]["value_change"] == pytest.approx(19.2 - 19.1)
+        assert result.iloc[2]["value_change"] == pytest.approx(19.3 - 19.2)
+
+    def test_value_change_pct_first_row_is_nan(self, macro_store):
+        result = read_macro_revisions("GDPC1", Q4_2019, macro_store)
+        assert pd.isna(result.iloc[0]["value_change_pct"])
+
+    def test_value_change_pct_second_row(self, macro_store):
+        result = read_macro_revisions("GDPC1", Q4_2019, macro_store)
+        expected_pct = (19.2 - 19.1) / 19.1 * 100
+        assert result.iloc[1]["value_change_pct"] == pytest.approx(expected_pct)
+
+    def test_single_vintage_has_nan_changes(self, macro_store):
+        """Q3 2019 has only one vintage; change columns are NaN."""
+        result = read_macro_revisions("GDPC1", Q3_2019, macro_store)
+        assert len(result) == 1
+        assert result.iloc[0]["revision_rank"] == 1
+        assert pd.isna(result.iloc[0]["value_change"])
+        assert pd.isna(result.iloc[0]["value_change_pct"])
+
+    def test_empty_for_missing_period(self, macro_store):
+        result = read_macro_revisions("GDPC1", datetime.date(2000, 1, 1), macro_store)
+        assert result.empty
+
+    def test_empty_for_missing_series(self, macro_store):
+        result = read_macro_revisions("NOPE", Q4_2019, macro_store)
+        assert result.empty
+
+    def test_empty_for_missing_table(self, tmp_path):
+        result = read_macro_revisions("GDPC1", Q4_2019, tmp_path)
+        assert result.empty


### PR DESCRIPTION
## Summary

- `storage.read_macro_as_of(series_ids, as_of_date, data_dir)` — point-in-time query returning the vintage current on a given date, with no look-ahead bias from subsequent revisions
- `storage.read_macro_revisions(series_id, period_start_date, data_dir)` — full revision chain for one observation with computed `revision_rank`, `value_change`, and `value_change_pct`
- `MACRO_SCHEMA` gains `revision_rank` (int32) and `release_name` (string, nullable); sort key now includes `report_date`
- Per-series incremental lookback: GDPC1/GDP use a 400-day window to catch annual benchmark revisions; all others keep 7 days
- `_detect_revisions()` logs `[macro] Revision detected: …` when a new vintage revisits an already-known observation period
- `_recompute_revision_ranks()` corrects ranks across the full stored series after each incremental write

## Test plan

- [ ] `pytest tests/test_fetch_macro.py tests/test_storage_macro.py` — 45 new/updated cases, all passing
- [ ] `pytest` full suite — 445 passed, no regressions
- [ ] `ruff check` — clean

Closes #42