### PR TITLE
fix: make _recompute_revision_ranks partition-aware (closes #53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented here.
 
 ---
 
+## [0.6.1] — 2026-04-16 ([#53](https://github.com/michaelk95/market_data/pull/53))
+
+### Fixed
+- `fetch_macro._recompute_revision_ranks()` now discovers partition files via
+  `PARTITION_COLS["macro"]` rather than hardcoding `data/macro/data.parquet`.
+  If the macro table is ever year-partitioned (like `ohlcv`, `fundamentals`,
+  `options`), ranks are recomputed correctly across all partition files instead
+  of silently doing nothing.
+- Extracted `fetch_macro._macro_partition_paths()` to centralise file
+  discovery for the macro table's current (unpartitioned) and any future
+  (year-partitioned) layout.
+
+---
+
 ## [0.6.0] — 2026-04-16 ([#42](https://github.com/michaelk95/market_data/pull/42))
 
 ### Added

--- a/src/market_data/fetch_macro.py
+++ b/src/market_data/fetch_macro.py
@@ -57,7 +57,7 @@ import pandas as pd
 
 from market_data.config import cfg as _cfg
 from market_data.resilience import fred_retry
-from market_data.schema import DataSource, ReportTimeMarker
+from market_data.schema import PARTITION_COLS, DataSource, ReportTimeMarker
 from market_data.storage import read_table, write_table
 
 logger = logging.getLogger(__name__)
@@ -230,6 +230,34 @@ def fetch_series_vintages(
 # Revision-rank maintenance
 # ---------------------------------------------------------------------------
 
+def _macro_partition_paths(data_dir: Path) -> list[Path]:
+    """Return all existing parquet paths holding macro data.
+
+    Handles both layouts:
+
+    - Unpartitioned (current):   ``data/macro/data.parquet``
+    - Year-partitioned (future): ``data/macro/year=YYYY/data.parquet``
+
+    Layout is determined from ``PARTITION_COLS["macro"]`` so this stays in
+    sync if the macro table is ever partitioned alongside ``ohlcv`` et al.
+    """
+    table_dir = data_dir / "macro"
+    if not table_dir.exists():
+        return []
+
+    if PARTITION_COLS.get("macro"):
+        return [
+            entry / "data.parquet"
+            for entry in sorted(table_dir.iterdir())
+            if entry.is_dir()
+            and entry.name.startswith("year=")
+            and (entry / "data.parquet").exists()
+        ]
+
+    single = table_dir / "data.parquet"
+    return [single] if single.exists() else []
+
+
 def _recompute_revision_ranks(series_id: str, data_dir: Path) -> None:
     """Recompute ``revision_rank`` for *series_id* across the entire stored dataset.
 
@@ -237,32 +265,58 @@ def _recompute_revision_ranks(series_id: str, data_dir: Path) -> None:
     incremental fetches (which only cover a lookback window) add new vintages
     to observations that already exist in storage.
 
-    Operates directly on the parquet file with an atomic tmp-rename write.
+    Works for both the unpartitioned macro layout (single ``data.parquet``) and
+    a year-partitioned layout; partition files are discovered via
+    ``_macro_partition_paths`` rather than hardcoded.  Each affected partition
+    file is rewritten atomically (tmp + rename).
     """
-    path = data_dir / "macro" / "data.parquet"
-    if not path.exists():
+    paths = _macro_partition_paths(data_dir)
+    if not paths:
         return
 
-    df = pd.read_parquet(path)
-    if "series_id" not in df.columns:
+    # Load every partition once; collect this series' rows across all of them
+    # so ranks can be recomputed globally.
+    frames: dict[Path, pd.DataFrame] = {p: pd.read_parquet(p) for p in paths}
+    series_slices = [
+        part.loc[part["series_id"] == series_id]
+        for part in frames.values()
+        if "series_id" in part.columns and (part["series_id"] == series_id).any()
+    ]
+    if not series_slices:
         return
 
-    mask = df["series_id"] == series_id
-    if not mask.any():
-        return
-
-    series_df = df.loc[mask].copy()
-    # Sort so cumcount is assigned in chronological vintage order
-    series_df = series_df.sort_values(["period_start_date", "report_date"])
-    series_df["revision_rank"] = (
-        series_df.groupby("period_start_date", sort=False).cumcount() + 1
+    combined = (
+        pd.concat(series_slices, ignore_index=True)
+        .sort_values(["period_start_date", "report_date"])
     )
-    # Align by index back into the full DataFrame
-    df.loc[mask, "revision_rank"] = series_df["revision_rank"]
+    combined["revision_rank"] = (
+        combined.groupby("period_start_date", sort=False).cumcount() + 1
+    )
 
-    tmp = path.with_name("data.tmp.parquet")
-    df.to_parquet(tmp, index=False)
-    tmp.replace(path)
+    # Join key includes series_id so the rank map cannot collide with rows
+    # from other series that happen to share a (period, report) pair.
+    rank_map = combined[
+        ["series_id", "period_start_date", "report_date", "revision_rank"]
+    ].rename(columns={"revision_rank": "_new_rank"})
+
+    for path, part in frames.items():
+        if "series_id" not in part.columns or not (part["series_id"] == series_id).any():
+            continue
+
+        merged = part.merge(
+            rank_map,
+            on=["series_id", "period_start_date", "report_date"],
+            how="left",
+        )
+        updated_mask = merged["_new_rank"].notna()
+        merged.loc[updated_mask, "revision_rank"] = (
+            merged.loc[updated_mask, "_new_rank"].astype(part["revision_rank"].dtype)
+        )
+        merged = merged.drop(columns=["_new_rank"])
+
+        tmp = path.with_name(path.stem + ".tmp.parquet")
+        merged.to_parquet(tmp, index=False)
+        tmp.replace(path)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_fetch_macro.py
+++ b/tests/test_fetch_macro.py
@@ -12,10 +12,11 @@ from market_data.fetch_macro import (
     SERIES_LOOKBACK_DAYS,
     _DEFAULT_LOOKBACK_DAYS,
     _detect_revisions,
+    _recompute_revision_ranks,
     fetch_series_vintages,
     update_series,
 )
-from market_data.schema import DataSource, ReportTimeMarker
+from market_data.schema import PARTITION_COLS, DataSource, ReportTimeMarker
 from market_data.storage import write_table
 
 
@@ -302,6 +303,39 @@ class TestUpdateSeries:
         stored = pd.read_parquet(tmp_path / "macro" / "data.parquet")
         stored = stored[stored["series_id"] == "GDPC1"].sort_values("report_date")
         assert list(stored["revision_rank"]) == [1, 2]
+
+    def test_revision_rank_recomputed_partitioned_layout(self, tmp_path, monkeypatch):
+        """If the macro table is ever year-partitioned, _recompute_revision_ranks
+        still discovers and rewrites every partition file for the series."""
+        # Simulate a partitioned macro layout.  PARTITION_COLS is a shared dict,
+        # so in-place setitem is visible to fetch_macro's imported reference.
+        monkeypatch.setitem(PARTITION_COLS, "macro", ["year"])
+
+        period_2019 = datetime.date(2019, 10, 1)
+        period_2020 = datetime.date(2020, 1, 1)
+
+        part_2019 = pd.DataFrame([
+            {**_seed_row("GDPC1", period_2019, datetime.date(2020, 1, 30)), "revision_rank": 99},
+            {**_seed_row("GDPC1", period_2019, datetime.date(2020, 3, 26)), "revision_rank": 99},
+        ])
+        part_2020 = pd.DataFrame([
+            {**_seed_row("GDPC1", period_2020, datetime.date(2020, 4, 30)), "revision_rank": 99},
+        ])
+
+        dir_2019 = tmp_path / "macro" / "year=2019"
+        dir_2020 = tmp_path / "macro" / "year=2020"
+        dir_2019.mkdir(parents=True)
+        dir_2020.mkdir(parents=True)
+        part_2019.to_parquet(dir_2019 / "data.parquet", index=False)
+        part_2020.to_parquet(dir_2020 / "data.parquet", index=False)
+
+        _recompute_revision_ranks("GDPC1", tmp_path)
+
+        stored_2019 = pd.read_parquet(dir_2019 / "data.parquet").sort_values("report_date")
+        stored_2020 = pd.read_parquet(dir_2020 / "data.parquet").sort_values("report_date")
+
+        assert list(stored_2019["revision_rank"]) == [1, 2]
+        assert list(stored_2020["revision_rank"]) == [1]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- \`_recompute_revision_ranks\` previously hardcoded \`data/macro/data.parquet\`, which would silently no-op if the macro table is ever year-partitioned like \`ohlcv\`, \`fundamentals\`, and \`options\`.
- Extracted \`_macro_partition_paths()\` to discover files from \`PARTITION_COLS["macro"]\`; handles both the current single-file layout and any future \`year=YYYY\` layout automatically.
- Rank recomputation now reads all partition files, builds a global rank map for the series, and rewrites each affected partition atomically.

## Implementation notes

**\`series_id\` in the merge key**

The rank map only contains rows for the one series being recomputed, but each partition file holds rows for all series. Without \`series_id\` in the join key, any two series that share a \`(period_start_date, report_date)\` pair — which happens constantly for daily series like DFF and T10Y2Y — would get each other's ranks applied. Including it makes the join a true point-in-time key match.

**dtype cast after the left-join**

A left-join promotes unmatched columns to \`float64\` because NaN has no integer representation. Without \`.astype(part["revision_rank"].dtype)\`, the updated ranks would be written back as floats, silently breaking the schema (\`revision_rank\` is \`int32\` in \`MACRO_SCHEMA\`). The cast restores the original dtype before writing.

## Test plan

- [x] Existing \`test_revision_rank_recomputed_after_incremental\` still passes (unpartitioned path unchanged)
- [x] New \`test_revision_rank_recomputed_partitioned_layout\` monkeypatches \`PARTITION_COLS["macro"]\` to \`["year"]\` and verifies ranks are corrected across two year partition files
- [x] Full suite: 446 passed, 0 failures