### PR TITLE
fix: widen incremental lookback window for PAYEMS, CPIAUCSL, CPILFESL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented here.
 
 ---
 
+## [0.6.1] — 2026-04-16 ([#54](https://github.com/michaelk95/market_data/pull/54))
+
+### Changed
+- `fetch_macro.SERIES_LOOKBACK_DAYS`: widened incremental lookback window for `PAYEMS`,
+  `CPIAUCSL`, and `CPILFESL` from 7 days to 400 days. These series are subject to annual
+  benchmark revisions (PAYEMS each February; CPI periodically) that can silently rewrite
+  years of history — a 7-day window would miss them entirely.
+
+---
+
 ## [0.6.0] — 2026-04-16 ([#42](https://github.com/michaelk95/market_data/pull/42))
 
 ### Added

--- a/src/market_data/fetch_macro.py
+++ b/src/market_data/fetch_macro.py
@@ -93,12 +93,19 @@ DEFAULT_SERIES: list[str] = list(
     ).keys()
 )
 
-# Incremental lookback window per series.  GDP annual revisions (released each
-# July) can silently revise observations from years prior, so quarterly GDP
-# series use a much wider window than the daily/monthly default.
+# Incremental lookback window per series.  Some FRED series are subject to
+# periodic revisions that can silently rewrite observations from years prior:
+#   - GDP / GDPC1: annual revisions every July
+#   - PAYEMS: annual benchmark revisions every February
+#   - CPIAUCSL / CPILFESL: periodic methodological revisions
+# A 400-day window covers one full annual revision cycle for each.  Series
+# not listed here use the 7-day default.
 SERIES_LOOKBACK_DAYS: dict[str, int] = {
-    "GDPC1": 400,
-    "GDP":   400,
+    "GDPC1":    400,  # annual GDP revisions each July
+    "GDP":      400,  # annual GDP revisions each July
+    "PAYEMS":   400,  # annual benchmark revisions each February
+    "CPIAUCSL": 400,  # periodic methodological revisions
+    "CPILFESL": 400,  # periodic methodological revisions
 }
 _DEFAULT_LOOKBACK_DAYS = 7
 

--- a/tests/test_fetch_macro.py
+++ b/tests/test_fetch_macro.py
@@ -5,6 +5,8 @@ import datetime
 import logging
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 import pandas as pd
 
 from market_data.fetch_macro import (
@@ -224,10 +226,29 @@ class TestUpdateSeries:
         expected = str(report_date - datetime.timedelta(days=expected_days))
         assert captured["realtime_start"] == expected
 
+    @pytest.mark.parametrize("series_id", ["PAYEMS", "CPIAUCSL", "CPILFESL"])
+    def test_annually_revised_series_uses_400_day_lookback(self, series_id, tmp_path):
+        """PAYEMS, CPIAUCSL, and CPILFESL use a 400-day window for annual benchmark revisions."""
+        report_date = datetime.date(2024, 7, 1)
+        seed = pd.DataFrame([_seed_row(series_id, datetime.date(2024, 6, 1), report_date)])
+        write_table(seed, "macro", tmp_path)
+
+        captured: dict = {}
+
+        def fake_fetch(sid, realtime_start, api_key):
+            captured["realtime_start"] = realtime_start
+            return pd.DataFrame()
+
+        with patch("market_data.fetch_macro.fetch_series_vintages", side_effect=fake_fetch):
+            update_series(series_id, api_key="test", start=DEFAULT_START, data_dir=tmp_path)
+
+        expected = str(report_date - datetime.timedelta(days=400))
+        assert captured["realtime_start"] == expected
+
     def test_default_series_uses_7_day_lookback(self, tmp_path):
         """Series not in SERIES_LOOKBACK_DAYS fall back to _DEFAULT_LOOKBACK_DAYS."""
         report_date = datetime.date(2024, 7, 1)
-        seed = pd.DataFrame([_seed_row("CPIAUCSL", datetime.date(2024, 6, 1), report_date)])
+        seed = pd.DataFrame([_seed_row("DFF", datetime.date(2024, 6, 1), report_date)])
         write_table(seed, "macro", tmp_path)
 
         captured: dict = {}
@@ -237,7 +258,7 @@ class TestUpdateSeries:
             return pd.DataFrame()
 
         with patch("market_data.fetch_macro.fetch_series_vintages", side_effect=fake_fetch):
-            update_series("CPIAUCSL", api_key="test", start=DEFAULT_START, data_dir=tmp_path)
+            update_series("DFF", api_key="test", start=DEFAULT_START, data_dir=tmp_path)
 
         expected = str(report_date - datetime.timedelta(days=_DEFAULT_LOOKBACK_DAYS))
         assert captured["realtime_start"] == expected


### PR DESCRIPTION
## Summary

- Adds `PAYEMS`, `CPIAUCSL`, and `CPILFESL` to `SERIES_LOOKBACK_DAYS` with a 400-day window
- The previous 7-day default silently missed annual benchmark revisions (PAYEMS each February) and periodic CPI methodological revisions that rewrite years of history
- 400 days covers one full annual revision cycle, consistent with the existing treatment of GDP series

## Retroactive gap

This fix protects future incremental runs only. Any deployment that has been running with the 7-day window before this merge may already have stale PAYEMS/CPI vintages in storage. To close that gap, re-pull full vintage history with:

```bash
market-data-migrate-macro --series PAYEMS CPIAUCSL CPILFESL
```

## Series not changed

`UNRATE`, `PCEPI`, and `PCEPILFE` are left at the 7-day default for now. UNRATE comes from the same BLS Employment Situation release as PAYEMS and is subject to the same annual benchmark revision; PCEPI/PCEPILFE have their own BEA revision schedule. Tracked in #57.

## Test plan

- [ ] `test_annually_revised_series_uses_400_day_lookback` — parametrized over PAYEMS, CPIAUCSL, CPILFESL — verifies each series uses a 400-day window
- [ ] `test_default_series_uses_7_day_lookback` — updated to use `DFF` (a genuinely default series) to verify the fallback still works
- [ ] All 29 existing tests pass

Closes #54