### PR TITLE
fix: widen incremental lookback window for UNRATE, PCEPI, PCEPILFE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented here.
 
 ---
 
+## [0.6.3] — 2026-04-16 ([#PR](https://github.com/michaelk95/market_data/pull/PR))
+
+### Changed
+- `fetch_macro.SERIES_LOOKBACK_DAYS`: widened incremental lookback window for `UNRATE`,
+  `PCEPI`, and `PCEPILFE` from 7 days to 400 days. `UNRATE` comes from the same BLS
+  Employment Situation release as `PAYEMS` and is revised each February alongside it;
+  `PCEPI`/`PCEPILFE` are subject to annual BEA comprehensive revisions every July that
+  can silently rewrite years of history.
+
+---
+
 ## [0.6.2] — 2026-04-16 ([#54](https://github.com/michaelk95/market_data/pull/54))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented here.
 
 ---
 
-## [0.6.3] — 2026-04-16 ([#PR](https://github.com/michaelk95/market_data/pull/PR))
+## [0.6.3] — 2026-04-16 ([#59](https://github.com/michaelk95/market_data/pull/59))
 
 ### Changed
 - `fetch_macro.SERIES_LOOKBACK_DAYS`: widened incremental lookback window for `UNRATE`,

--- a/src/market_data/fetch_macro.py
+++ b/src/market_data/fetch_macro.py
@@ -96,16 +96,20 @@ DEFAULT_SERIES: list[str] = list(
 # Incremental lookback window per series.  Some FRED series are subject to
 # periodic revisions that can silently rewrite observations from years prior:
 #   - GDP / GDPC1: annual revisions every July
-#   - PAYEMS: annual benchmark revisions every February
-#   - CPIAUCSL / CPILFESL: periodic methodological revisions
+#   - PAYEMS / UNRATE: annual BLS benchmark revisions every February
+#   - CPIAUCSL / CPILFESL: periodic BLS methodological revisions
+#   - PCEPI / PCEPILFE: annual BEA comprehensive revisions every July
 # A 400-day window covers one full annual revision cycle for each.  Series
 # not listed here use the 7-day default.
 SERIES_LOOKBACK_DAYS: dict[str, int] = {
     "GDPC1":    400,  # annual GDP revisions each July
     "GDP":      400,  # annual GDP revisions each July
-    "PAYEMS":   400,  # annual benchmark revisions each February
-    "CPIAUCSL": 400,  # periodic methodological revisions
-    "CPILFESL": 400,  # periodic methodological revisions
+    "PAYEMS":   400,  # annual BLS benchmark revisions each February
+    "UNRATE":   400,  # annual BLS benchmark revisions each February
+    "CPIAUCSL": 400,  # periodic BLS methodological revisions
+    "CPILFESL": 400,  # periodic BLS methodological revisions
+    "PCEPI":    400,  # annual BEA comprehensive revisions each July
+    "PCEPILFE": 400,  # annual BEA comprehensive revisions each July
 }
 _DEFAULT_LOOKBACK_DAYS = 7
 

--- a/tests/test_fetch_macro.py
+++ b/tests/test_fetch_macro.py
@@ -227,9 +227,9 @@ class TestUpdateSeries:
         expected = str(report_date - datetime.timedelta(days=expected_days))
         assert captured["realtime_start"] == expected
 
-    @pytest.mark.parametrize("series_id", ["PAYEMS", "CPIAUCSL", "CPILFESL"])
+    @pytest.mark.parametrize("series_id", ["PAYEMS", "CPIAUCSL", "CPILFESL", "UNRATE", "PCEPI", "PCEPILFE"])
     def test_annually_revised_series_uses_400_day_lookback(self, series_id, tmp_path):
-        """PAYEMS, CPIAUCSL, and CPILFESL use a 400-day window for annual benchmark revisions."""
+        """BLS/BEA benchmark-revised series use a 400-day window to catch annual revisions."""
         report_date = datetime.date(2024, 7, 1)
         seed = pd.DataFrame([_seed_row(series_id, datetime.date(2024, 6, 1), report_date)])
         write_table(seed, "macro", tmp_path)


### PR DESCRIPTION
## Summary

- Adds `UNRATE`, `PCEPI`, and `PCEPILFE` to `SERIES_LOOKBACK_DAYS` with a 400-day window
- The previous 7-day default silently missed annual benchmark revisions for all three series
- `UNRATE` comes from the same BLS Employment Situation release as `PAYEMS` and is revised alongside it each February
- `PCEPI`/`PCEPILFE` are subject to annual BEA comprehensive revisions every July

## Retroactive gap

This fix protects future incremental runs only. Any deployment that has been running with the 7-day window before this merge may already have stale vintages in storage. To close that gap, re-pull full vintage history with:

```bash
market-data-migrate-macro --series UNRATE PCEPI PCEPILFE
```

## Test plan

- [ ] `test_annually_revised_series_uses_400_day_lookback` — parametrize list extended to include `UNRATE`, `PCEPI`, `PCEPILFE` — 6 parametrized cases total (was 3)
- [ ] All 33 existing tests pass

Closes #57