### PR TITLE
feat: add market_data.version() and __version__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented here.
 
 ---
 
+## [0.6.3] — 2026-04-16 ([#58](https://github.com/michaelk95/market_data/issues/58))
+
+### Added
+- `market_data.version()` returns `{"version": ..., "sha": ...}` for experiment provenance.
+- `market_data.__version__` is a plain string of the installed package version.
+- SHA falls back to `"unknown"` if git is unavailable.
+
+---
+
 ## [0.6.2] — 2026-04-16 ([#54](https://github.com/michaelk95/market_data/pull/54))
 
 ### Changed

--- a/src/market_data/__init__.py
+++ b/src/market_data/__init__.py
@@ -1,3 +1,3 @@
-from importlib.metadata import version
+from market_data.version import version
 
-__version__ = version("market_data")
+__version__ = version()["version"]

--- a/src/market_data/version.py
+++ b/src/market_data/version.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import subprocess
+from importlib.metadata import version as _pkg_version
+from pathlib import Path
+
+
+def version() -> dict:
+    pkg = _pkg_version("market_data")
+    try:
+        sha = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=Path(__file__).parent,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except Exception:
+        sha = "unknown"
+    return {"version": pkg, "sha": sha}

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import market_data
+from market_data.version import version
+
+
+class TestVersion:
+    def test_returns_dict_with_required_keys(self):
+        result = version()
+        assert "version" in result
+        assert "sha" in result
+
+    def test_version_string_is_str(self):
+        result = version()
+        assert isinstance(result["version"], str)
+        assert result["version"] != ""
+
+    def test_sha_is_str(self):
+        result = version()
+        assert isinstance(result["sha"], str)
+        assert result["sha"] != ""
+
+    def test_sha_fallback_on_git_unavailable(self):
+        with patch("subprocess.check_output", side_effect=FileNotFoundError):
+            result = version()
+        assert result["sha"] == "unknown"
+
+    def test_sha_fallback_on_subprocess_error(self):
+        import subprocess
+        with patch("subprocess.check_output", side_effect=subprocess.CalledProcessError(128, "git")):
+            result = version()
+        assert result["sha"] == "unknown"
+
+
+class TestDunderVersion:
+    def test_module_version_is_plain_string(self):
+        assert isinstance(market_data.__version__, str)
+        assert market_data.__version__ != ""
+
+    def test_matches_version_function(self):
+        assert market_data.__version__ == version()["version"]


### PR DESCRIPTION
Closes #58.

## Summary
- Adds `src/market_data/version.py` with a `version()` function returning `{"version": ..., "sha": ...}`
- Updates `__init__.py` to expose `version` and set `__version__` as a plain string
- SHA falls back to `"unknown"` if git is unavailable

## Test plan
- [ ] `tests/test_version.py` — 7 tests covering dict shape, types, fallbacks, and `__version__` consistency