### PR TITLE
feat(MD-02): add date_removed column to tickers.csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented here.
 
 ---
 
+## [0.7.0] — 2026-04-16 ([#PR](https://github.com/michaelk95/market_data/pull/PR))
+
+### Added
+- `tickers.csv` now includes a `date_removed` column. When a ticker drops out of
+  both the Russell 2000 and S&P 500 on a refresh run, `date_removed` is set to
+  that run's date and preserved on all subsequent runs. Active tickers have an
+  empty `date_removed`. This enables point-in-time universe filtering in
+  downstream consumers (e.g. `smelt`'s `ore.universe(as_of)`).
+
+---
+
 ## [0.6.3] — 2026-04-16 ([#59](https://github.com/michaelk95/market_data/pull/59))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented here.
 
 ---
 
-## [0.7.0] — 2026-04-16 ([#PR](https://github.com/michaelk95/market_data/pull/PR))
+## [0.7.0] — 2026-04-16 ([#62](https://github.com/michaelk95/market_data/pull/62))
 
 ### Added
 - `tickers.csv` now includes a `date_removed` column. When a ticker drops out of

--- a/src/market_data/fetch_tickers.py
+++ b/src/market_data/fetch_tickers.py
@@ -211,7 +211,7 @@ def apply_date_added(
 
     # Build lookups from existing file
     known_date_added = dict(zip(existing_df["symbol"], existing_df["date_added"]))
-    known_date_removed = dict(zip(existing_df["symbol"], existing_df["date_removed"]))
+    dict(zip(existing_df["symbol"], existing_df["date_removed"]))
 
     # Active tickers: preserve date_added, clear date_removed
     new_df = new_df.copy()

--- a/src/market_data/fetch_tickers.py
+++ b/src/market_data/fetch_tickers.py
@@ -180,19 +180,23 @@ def apply_date_added(
     today: str,
 ) -> pd.DataFrame:
     """
-    Assign a date_added column to new_df by merging with an existing tickers.csv.
+    Assign date_added and date_removed columns to new_df by merging with an
+    existing tickers.csv.
 
     Rules:
-    - New tickers (not in existing file) get date_added = today.
-    - Existing tickers keep their original date_added.
-    - Tickers that dropped out of both indices are carried forward unchanged
-      (avoids survivorship bias).
+    - New tickers (not in existing file) get date_added = today, date_removed = "".
+    - Existing active tickers keep their original date_added; date_removed = "".
+    - Tickers that dropped out of both indices are carried forward with their
+      original date_added. date_removed is set to today on the first run that
+      notices them missing; subsequent runs preserve that date.
     - Backward-compat backfill: if existing file has no date_added column,
-      all its rows get "2000-01-01"; if no index column, they get "RUT2000".
+      all its rows get "2000-01-01"; if no index column, they get "RUT2000";
+      if no date_removed column, all rows get "".
     """
     if not existing_path.exists():
         new_df = new_df.copy()
         new_df["date_added"] = today
+        new_df["date_removed"] = ""
         return new_df
 
     existing_df = pd.read_csv(existing_path, dtype=str)
@@ -202,19 +206,28 @@ def apply_date_added(
         existing_df["date_added"] = "2000-01-01"
     if "index" not in existing_df.columns:
         existing_df["index"] = "RUT2000"
+    if "date_removed" not in existing_df.columns:
+        existing_df["date_removed"] = ""
 
-    # Build lookup: symbol -> date_added from existing file
-    known = dict(zip(existing_df["symbol"], existing_df["date_added"]))
+    # Build lookups from existing file
+    known_date_added = dict(zip(existing_df["symbol"], existing_df["date_added"]))
+    known_date_removed = dict(zip(existing_df["symbol"], existing_df["date_removed"]))
 
-    # Assign date_added: preserve existing dates, new tickers get today
+    # Active tickers: preserve date_added, clear date_removed
     new_df = new_df.copy()
-    new_df["date_added"] = new_df["symbol"].map(known).fillna(today)
+    new_df["date_added"] = new_df["symbol"].map(known_date_added).fillna(today)
+    new_df["date_removed"] = ""
 
     # Carry forward any tickers that dropped out of both indices
     new_symbols = set(new_df["symbol"])
     dropped = existing_df[~existing_df["symbol"].isin(new_symbols)].copy()
 
     if not dropped.empty:
+        # Set date_removed to today only on the first run that detects the drop;
+        # subsequent runs preserve the original removal date.
+        dropped["date_removed"] = dropped["date_removed"].apply(
+            lambda d: d if d else today
+        )
         # Ensure dropped rows have the same columns as new_df
         for col in new_df.columns:
             if col not in dropped.columns:
@@ -285,7 +298,7 @@ def run(out_path: Path, today: str | None = None) -> pd.DataFrame:
     if result.empty:
         raise ValueError("No tickers after merging — CSV format may have changed.")
 
-    result[["symbol", "name", "market_value", "index", "date_added"]].to_csv(
+    result[["symbol", "name", "market_value", "index", "date_added", "date_removed"]].to_csv(
         out_path, index=False
     )
     return result

--- a/tests/test_fetch_tickers.py
+++ b/tests/test_fetch_tickers.py
@@ -156,6 +156,7 @@ class TestApplyDateAdded:
         )
         result = apply_date_added(new_df, tmp_path / "nonexistent.csv", "2024-01-15")
         assert (result["date_added"] == "2024-01-15").all()
+        assert (result["date_removed"] == "").all()
 
     def test_existing_symbol_preserves_original_date(self, tmp_path):
         existing = pd.DataFrame(
@@ -229,16 +230,71 @@ class TestApplyDateAdded:
         )
         result = apply_date_added(new_df, csv_path, "2024-01-15")
         assert "DROPPED" in result["symbol"].values
+        dropped_row = result[result["symbol"] == "DROPPED"]
+        assert dropped_row["date_removed"].iloc[0] == "2024-01-15"
 
-    def test_backfill_missing_date_added_column(self, tmp_path):
-        """Old CSV without date_added column gets backfilled with '2000-01-01'."""
+    def test_already_dropped_ticker_keeps_date_removed(self, tmp_path):
+        """A ticker dropped in a prior run keeps its original date_removed."""
+        existing = pd.DataFrame(
+            {
+                "symbol": ["AAPL", "DROPPED"],
+                "name": ["Apple", "Dropped Corp"],
+                "market_value": [1_000_000.0, 50_000.0],
+                "index": ["SP500", "SP500"],
+                "date_added": ["2023-01-01", "2022-01-01"],
+                "date_removed": ["", "2024-01-15"],
+            }
+        )
+        csv_path = tmp_path / "tickers.csv"
+        existing.to_csv(csv_path, index=False)
+
+        new_df = pd.DataFrame(
+            {
+                "symbol": ["AAPL"],
+                "name": ["Apple Inc."],
+                "market_value": [1_100_000.0],
+                "index": ["SP500"],
+            }
+        )
+        result = apply_date_added(new_df, csv_path, "2024-06-01")
+        dropped_row = result[result["symbol"] == "DROPPED"]
+        assert dropped_row["date_removed"].iloc[0] == "2024-01-15"
+
+    def test_active_ticker_has_empty_date_removed(self, tmp_path):
+        """Active tickers always have an empty date_removed."""
         existing = pd.DataFrame(
             {
                 "symbol": ["AAPL"],
                 "name": ["Apple"],
                 "market_value": [1_000_000.0],
                 "index": ["SP500"],
-                # no date_added column
+                "date_added": ["2023-01-01"],
+                "date_removed": [""],
+            }
+        )
+        csv_path = tmp_path / "tickers.csv"
+        existing.to_csv(csv_path, index=False)
+
+        new_df = pd.DataFrame(
+            {
+                "symbol": ["AAPL"],
+                "name": ["Apple Inc."],
+                "market_value": [1_100_000.0],
+                "index": ["SP500"],
+            }
+        )
+        result = apply_date_added(new_df, csv_path, "2024-06-01")
+        assert result.loc[result["symbol"] == "AAPL", "date_removed"].iloc[0] == ""
+
+    def test_backfill_missing_date_added_column(self, tmp_path):
+        """Old CSV without date_added or date_removed columns gets backfilled."""
+        existing = pd.DataFrame(
+            {
+                "symbol": ["AAPL"],
+                "name": ["Apple"],
+                "market_value": [1_000_000.0],
+                "index": ["SP500"],
+                # no date_added or date_removed columns
             }
         )
         csv_path = tmp_path / "tickers.csv"
@@ -255,6 +311,7 @@ class TestApplyDateAdded:
         result = apply_date_added(new_df, csv_path, "2024-01-15")
         # AAPL was in old CSV, so it gets the backfilled date, not today
         assert result.loc[result["symbol"] == "AAPL", "date_added"].iloc[0] == "2000-01-01"
+        assert result.loc[result["symbol"] == "AAPL", "date_removed"].iloc[0] == ""
 
     def test_no_duplicate_symbols_in_output(self, tmp_path):
         """The output should not contain duplicate symbols."""


### PR DESCRIPTION
## Summary

Closes #60 (MD-02).

MD-01 confirmed complete survivorship bias: all 2427 symbols in `data/ohlcv/` are active today, ratio = 1.000 for every year 2016–2026. The root cause is that `fetch_tickers.py` only ever collected data for current index constituents; delisted symbols were never retained.

The `apply_date_added()` function already carried dropped tickers forward in `tickers.csv`, but there was no `date_removed` column, so downstream consumers (`smelt`'s `ore.universe(as_of)`) had no way to know *when* a ticker left the index and couldn't do point-in-time universe filtering.

### Changes

- **`fetch_tickers.py` — `apply_date_added()`**: adds `date_removed` column
  - When a ticker is first detected as dropped (not in the latest IWM/IVV fetch), `date_removed` is set to that run's date
  - On subsequent runs, the original `date_removed` is preserved
  - Active tickers always have `date_removed = ""`
  - Backward-compat: old CSVs without the column get `""` backfilled
- **`fetch_tickers.py` — `run()`**: writes `date_removed` to the CSV
- **`tests/test_fetch_tickers.py`**: 3 new tests + 2 updated tests covering the new column

### What this enables

`smelt`'s `ore.universe(as_of)` can now filter:
```python
date_added <= as_of AND (date_removed == "" OR date_removed > as_of)
```
to return the historically-correct constituent universe at any point in time.

### What this does NOT fix

Historical delistings before the pipeline was bootstrapped are still missing — that's MD-03 (one-time backfill). MD-02 only ensures the mechanism is correct going forward.

---

## Additional notes for reviewers

**`date_removed` precision is ±90 days.** The ticker refresh only runs every 90 days (`TICKER_REFRESH_DAYS = 90`). A stock removed from the index on day 1 of the cycle won't get `date_removed` stamped until day 90 when the next refresh fires. `date_removed` should be read as *"first detected missing in this 90-day window"*, not the exact exit date. Fine for monthly/quarterly-rebalanced backtests, but `ore.universe()` consumers should document this as a known approximation rather than treat it as a precise delist date.

**The update step keeps fetching dropped tickers — intentionally.** `step_update()` iterates over `all_tickers`, which includes carried-forward symbols with `date_removed` set. A stock removed from an index doesn't immediately stop trading, so incremental OHLCV fetches continue until yfinance returns nothing and the quarantine threshold (5 consecutive failures) is hit. The practical consequence: the parquet file accumulates actual trading data up to the stock's true quiet date. The last row in the parquet is a more precise signal for "when did this stock go dark" than `date_removed` is.

**No manual migration needed.** Existing `tickers.csv` files have no `date_removed` column. The backward-compat path in `apply_date_added()` silently backfills `""` for all rows on the first refresh run, then writes the column going forward. Nothing to run manually.

## Test plan

- [x] All 32 `test_fetch_tickers.py` tests pass
- [x] Full suite: 454 passed, 0 failed