### PR TITLE
fix: chunk FRED vintage requests and derive realtime_end locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented here.
 
 ---
 
+## [0.6.5] — 2026-04-17 ([#63](https://github.com/michaelk95/market_data/issues/63))
+
+### Fixed
+- `fetch_macro`: chunked `get_series_all_releases` calls into 4-year windows to stay under FRED's 2000-vintage-date-per-request limit (was causing HTTP 400 for DFF and T10Y2Y on bootstrap and long lookback windows).
+- `fetch_macro`: derived `realtime_end` / `valid_to_date` from the vintage chain instead of reading it from the fredapi response (fredapi never returned that column).
+
+---
+
 ## [0.6.4] — 2026-04-16 ([#58](https://github.com/michaelk95/market_data/issues/58))
 
 ### Added

--- a/src/market_data/fetch_macro.py
+++ b/src/market_data/fetch_macro.py
@@ -112,6 +112,10 @@ SERIES_LOOKBACK_DAYS: dict[str, int] = {
     "PCEPILFE": 400,  # annual BEA comprehensive revisions each July
 }
 _DEFAULT_LOOKBACK_DAYS = 7
+# FRED limits get_series_all_releases to 2000 vintage dates per request. Daily series like DFF
+# accumulate ~140 vintage dates/year, so a full bootstrap from 1990 hits ~5000. Chunk requests
+# into 4-year windows to stay safely under the limit for all series frequencies.
+_VINTAGE_CHUNK_YEARS = 4
 
 # Static FRED release names for default series (best-effort; None for unknowns)
 _SERIES_RELEASE_NAMES: dict[str, str] = {
@@ -133,6 +137,8 @@ _EMPTY_COLS: list[str] = [
     "period_start_date", "period_end_date",
     "report_date", "report_time_marker", "source", "collected_at",
 ]
+
+_FAR_FUTURE = date(9999, 12, 31)
 
 
 # ---------------------------------------------------------------------------
@@ -163,6 +169,74 @@ def _load_api_key() -> str:
 
 
 # ---------------------------------------------------------------------------
+# Fetch helpers
+# ---------------------------------------------------------------------------
+
+def _derive_realtime_end(df: pd.DataFrame) -> pd.Series:
+    """
+    Reconstruct realtime_end for each vintage row.
+
+    fredapi's get_series_all_releases does not return realtime_end, so we derive
+    it: for each observation date, the realtime_end of vintage N is one day before
+    the realtime_start of vintage N+1. The last vintage for each date gets 9999-12-31.
+    """
+    rs = pd.to_datetime(df["realtime_start"]).dt.date
+    ob = pd.to_datetime(df["date"]).dt.date
+    tmp = pd.DataFrame({"ob": ob, "rs": rs}, index=df.index).sort_values(["ob", "rs"])
+    tmp["next_rs"] = tmp.groupby("ob")["rs"].shift(-1)
+    return (
+        tmp["next_rs"]
+        .apply(lambda d: (d - timedelta(days=1)) if pd.notna(d) else _FAR_FUTURE)
+        .reindex(df.index)
+    )
+
+
+def _fetch_all_releases_chunked(
+    fred: object,
+    series_id: str,
+    realtime_start: str,
+    realtime_end: str,
+) -> pd.DataFrame:
+    """
+    Call get_series_all_releases in 4-year windows to stay under FRED's 2000
+    vintage-date-per-request limit. Results are concatenated and deduplicated.
+    """
+    start = date.fromisoformat(realtime_start)
+    end = date.fromisoformat(realtime_end)
+
+    frames: list[pd.DataFrame] = []
+    chunk_start = start
+    while chunk_start <= end:
+        try:
+            chunk_end = (
+                date(chunk_start.year + _VINTAGE_CHUNK_YEARS, chunk_start.month, chunk_start.day)
+                - timedelta(days=1)
+            )
+        except ValueError:
+            # chunk_start is Feb 29 in a leap year; next same date may not exist
+            chunk_end = date(chunk_start.year + _VINTAGE_CHUNK_YEARS, 2, 28)
+        chunk_end = min(chunk_end, end)
+
+        raw = fred.get_series_all_releases(  # type: ignore[union-attr]
+            series_id,
+            realtime_start=str(chunk_start),
+            realtime_end=str(chunk_end),
+        )
+        if raw is not None and not (hasattr(raw, "empty") and raw.empty):
+            frames.append(raw)
+        chunk_start = chunk_end + timedelta(days=1)
+
+    if not frames:
+        return pd.DataFrame()
+
+    return (
+        pd.concat(frames, ignore_index=True)
+        .drop_duplicates(subset=["realtime_start", "date"])
+        .reset_index(drop=True)
+    )
+
+
+# ---------------------------------------------------------------------------
 # Fetch
 # ---------------------------------------------------------------------------
 
@@ -175,8 +249,9 @@ def fetch_series_vintages(
     """
     Pull all vintages of a FRED series from *realtime_start* to today.
 
-    Uses ``get_series_all_releases`` so each row carries the vintage date
-    (``report_date``) and supersession date (``valid_to_date``), enabling
+    Uses ``get_series_all_releases`` (chunked into 4-year windows to stay under
+    FRED's 2000-vintage-date limit) so each row carries the vintage date
+    (``report_date``) and derived supersession date (``valid_to_date``), enabling
     point-in-time queries that are free of look-ahead bias from revisions.
 
     Also populates:
@@ -198,13 +273,11 @@ def fetch_series_vintages(
         ) from exc
 
     fred = fredapi.Fred(api_key=api_key)
-    raw = fred.get_series_all_releases(series_id, realtime_start=realtime_start)
+    df = _fetch_all_releases_chunked(fred, series_id, realtime_start, str(date.today()))
 
-    if raw is None or raw.empty:
+    if df.empty:
         return pd.DataFrame(columns=_EMPTY_COLS)
 
-    # After reset_index(), columns are: realtime_start, realtime_end, date, value
-    df = raw.reset_index()
     df = df.dropna(subset=["value"])
     if df.empty:
         return pd.DataFrame(columns=_EMPTY_COLS)
@@ -212,10 +285,7 @@ def fetch_series_vintages(
     df["period_start_date"] = pd.to_datetime(df["date"]).dt.date
     df["period_end_date"] = df["period_start_date"]
     df["report_date"] = pd.to_datetime(df["realtime_start"]).dt.date
-    # Avoid pd.to_datetime here: it overflows on 9999-12-31 in pandas < 2.0
-    df["valid_to_date"] = df["realtime_end"].apply(
-        lambda d: d if isinstance(d, date) else pd.Timestamp(d).date()
-    )
+    df["valid_to_date"] = _derive_realtime_end(df)
     df["series_id"] = series_id
     df["report_time_marker"] = ReportTimeMarker.POST_MARKET
     df["source"] = DataSource.FRED

--- a/tests/test_fetch_macro.py
+++ b/tests/test_fetch_macro.py
@@ -13,7 +13,10 @@ from market_data.fetch_macro import (
     DEFAULT_START,
     SERIES_LOOKBACK_DAYS,
     _DEFAULT_LOOKBACK_DAYS,
+    _VINTAGE_CHUNK_YEARS,
     _detect_revisions,
+    _derive_realtime_end,
+    _fetch_all_releases_chunked,
     _recompute_revision_ranks,
     fetch_series_vintages,
     update_series,
@@ -23,25 +26,18 @@ from market_data.storage import write_table
 
 
 # ---------------------------------------------------------------------------
-# Shared fixture — mimics what fredapi.get_series_all_releases returns
-# (index=realtime_start, columns=realtime_end/date/value)
+# Shared fixture — mimics what fredapi.get_series_all_releases actually returns.
+# fredapi returns a plain DataFrame with integer index and columns:
+#   realtime_start, date, value
+# (realtime_end is commented out in fredapi source and not returned)
 # ---------------------------------------------------------------------------
-
-_VINTAGE_INDEX = pd.Index(
-    [
-        datetime.date(2020, 1, 30),  # first vintage of 2019-Q4
-        datetime.date(2020, 3, 26),  # revised vintage of 2019-Q4
-        datetime.date(2020, 1, 30),  # first vintage of 2019-Q3
-    ],
-    name="realtime_start",
-)
 
 _VINTAGE_DF = pd.DataFrame(
     {
-        "realtime_end": [
-            datetime.date(2020, 3, 25),   # superseded
-            datetime.date(9999, 12, 31),  # currently active
-            datetime.date(9999, 12, 31),  # currently active
+        "realtime_start": [
+            datetime.date(2020, 1, 30),  # first vintage of 2019-Q4
+            datetime.date(2020, 3, 26),  # revised vintage of 2019-Q4
+            datetime.date(2020, 1, 30),  # first vintage of 2019-Q3
         ],
         "date": [
             datetime.date(2019, 10, 1),
@@ -49,8 +45,7 @@ _VINTAGE_DF = pd.DataFrame(
             datetime.date(2019, 7, 1),
         ],
         "value": [19.1, 19.2, 18.9],
-    },
-    index=_VINTAGE_INDEX,
+    }
 )
 
 
@@ -126,14 +121,8 @@ class TestFetchSeriesVintages:
         assert (result["report_time_marker"] == ReportTimeMarker.POST_MARKET).all()
 
     def test_drops_nan_value_rows(self):
-        df_with_nan = pd.DataFrame(
-            {
-                "realtime_end": _VINTAGE_DF["realtime_end"].tolist(),
-                "date": _VINTAGE_DF["date"].tolist(),
-                "value": [19.1, float("nan"), 18.9],
-            },
-            index=_VINTAGE_INDEX,
-        )
+        df_with_nan = _VINTAGE_DF.copy()
+        df_with_nan["value"] = [19.1, float("nan"), 18.9]
         result = self._call(df=df_with_nan)
         assert len(result) == 2
 
@@ -167,6 +156,110 @@ class TestFetchSeriesVintages:
         with patch("fredapi.Fred", return_value=_make_fred_mock(_VINTAGE_DF)):
             result = fetch_series_vintages("CUSTOM_XYZ", realtime_start="2020-01-01", api_key="test")
         assert result["release_name"].isna().all()
+
+
+# ---------------------------------------------------------------------------
+# TestDeriveRealtimeEnd
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveRealtimeEnd:
+    """Unit tests for _derive_realtime_end()."""
+
+    def test_single_vintage_gets_far_future(self):
+        df = pd.DataFrame({
+            "realtime_start": [datetime.date(2020, 1, 30)],
+            "date": [datetime.date(2019, 10, 1)],
+            "value": [19.1],
+        })
+        result = _derive_realtime_end(df)
+        assert result.iloc[0] == datetime.date(9999, 12, 31)
+
+    def test_superseded_vintage_gets_next_start_minus_one_day(self):
+        df = pd.DataFrame({
+            "realtime_start": [datetime.date(2020, 1, 30), datetime.date(2020, 3, 26)],
+            "date": [datetime.date(2019, 10, 1), datetime.date(2019, 10, 1)],
+            "value": [19.1, 19.2],
+        })
+        result = _derive_realtime_end(df)
+        assert result.iloc[0] == datetime.date(2020, 3, 25)
+        assert result.iloc[1] == datetime.date(9999, 12, 31)
+
+    def test_independent_observation_dates_do_not_cross(self):
+        """Vintages for different observation dates are bucketed independently."""
+        df = _VINTAGE_DF.copy()
+        result = _derive_realtime_end(df)
+        # 2019-Q4 first vintage: superseded by 2020-03-26 → realtime_end = 2020-03-25
+        q4_first = df[(df["date"] == datetime.date(2019, 10, 1)) & (df["realtime_start"] == datetime.date(2020, 1, 30))].index[0]
+        assert result.loc[q4_first] == datetime.date(2020, 3, 25)
+        # 2019-Q3 only vintage → 9999-12-31
+        q3 = df[df["date"] == datetime.date(2019, 7, 1)].index[0]
+        assert result.loc[q3] == datetime.date(9999, 12, 31)
+
+    def test_preserves_input_row_order(self):
+        """Result is aligned to the original DataFrame index, not sorted order."""
+        df = pd.DataFrame({
+            "realtime_start": [datetime.date(2020, 3, 26), datetime.date(2020, 1, 30)],
+            "date": [datetime.date(2019, 10, 1), datetime.date(2019, 10, 1)],
+            "value": [19.2, 19.1],
+        })
+        result = _derive_realtime_end(df)
+        # Row 0 is the later vintage → 9999-12-31
+        assert result.iloc[0] == datetime.date(9999, 12, 31)
+        # Row 1 is the earlier vintage → superseded day before row 0's realtime_start
+        assert result.iloc[1] == datetime.date(2020, 3, 25)
+
+
+# ---------------------------------------------------------------------------
+# TestFetchAllReleasesChunked
+# ---------------------------------------------------------------------------
+
+
+class TestFetchAllReleasesChunked:
+    """Unit tests for _fetch_all_releases_chunked()."""
+
+    def test_single_chunk_when_range_fits(self):
+        """A range shorter than _VINTAGE_CHUNK_YEARS issues exactly one API call."""
+        fred = MagicMock()
+        fred.get_series_all_releases.return_value = _VINTAGE_DF.copy()
+        result = _fetch_all_releases_chunked(fred, "GDPC1", "2023-01-01", "2023-12-31")
+        assert fred.get_series_all_releases.call_count == 1
+        assert len(result) == len(_VINTAGE_DF)
+
+    def test_multiple_chunks_for_long_range(self):
+        """A range spanning more than _VINTAGE_CHUNK_YEARS issues multiple API calls."""
+        fred = MagicMock()
+        fred.get_series_all_releases.return_value = pd.DataFrame(
+            {"realtime_start": [], "date": [], "value": []}
+        )
+        span_years = _VINTAGE_CHUNK_YEARS * 3
+        start = datetime.date(2000, 1, 1)
+        end = datetime.date(start.year + span_years, 1, 1)
+        _fetch_all_releases_chunked(fred, "DFF", str(start), str(end))
+        assert fred.get_series_all_releases.call_count >= 3
+
+    def test_deduplicates_overlapping_rows(self):
+        """Identical (realtime_start, date) rows from multiple chunks appear once."""
+        fred = MagicMock()
+        fred.get_series_all_releases.return_value = _VINTAGE_DF.copy()
+        result = _fetch_all_releases_chunked(fred, "GDPC1", "2020-01-01", "2026-04-17")
+        assert result.duplicated(subset=["realtime_start", "date"]).sum() == 0
+
+    def test_empty_when_all_chunks_return_nothing(self):
+        fred = MagicMock()
+        fred.get_series_all_releases.return_value = pd.DataFrame()
+        result = _fetch_all_releases_chunked(fred, "GDPC1", "2020-01-01", "2020-12-31")
+        assert result.empty
+
+    def test_chunk_realtime_end_never_exceeds_requested_end(self):
+        """Each chunk's realtime_end kwarg must not exceed the overall end date."""
+        fred = MagicMock()
+        fred.get_series_all_releases.return_value = pd.DataFrame()
+        overall_end = "2021-06-15"
+        _fetch_all_releases_chunked(fred, "DFF", "2020-01-01", overall_end)
+        for call in fred.get_series_all_releases.call_args_list:
+            chunk_end = call.kwargs.get("realtime_end") or call.args[2]
+            assert chunk_end <= overall_end
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #63

## Root causes

**1. HTTP 400 — too many vintage dates (DFF, T10Y2Y)**

`get_series_all_releases` was called with a single request spanning 1990–today. FRED limits responses to 2000 vintage dates per request; daily series like DFF accumulate ~140/year so a full bootstrap hit ~5000 and returned 400.

**2. KeyError: 'realtime_end' (CPI, PCE, GDP series)**

`fredapi`'s `get_series_all_releases` has `realtime_end` commented out in its source — the column is never returned. The code was reading a column that never existed.

## Fix

- `_fetch_all_releases_chunked`: splits the `[realtime_start, today]` window into 4-year chunks before calling the FRED API, staying safely under the 2000-vintage-date limit for all series frequencies.
- `_derive_realtime_end`: reconstructs `valid_to_date` from the vintage chain — for each observation date, `realtime_end[n] = realtime_start[n+1] - 1 day`; the latest vintage gets `9999-12-31`.

## Tests

- Updated `_VINTAGE_DF` fixture to match what fredapi actually returns (no `realtime_end`, plain integer index).
- Added `TestDeriveRealtimeEnd` (4 cases) and `TestFetchAllReleasesChunked` (5 cases).
- All 42 tests pass.