### PR TITLE
feat: constituent history fetch and OHLCV backfill (MD-03)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented here.
 
 ---
 
+## [0.7.0] — 2026-04-17 ([#TBD](https://github.com/michaelk95/market_data/pull/TBD))
+
+### Added
+- `fetch_constituent_history.py`: downloads historical S&P 500 constituent
+  membership from the fja05680/sp500 dataset (`sp500_ticker_start_end.csv`)
+  and writes `data/constituent_history.parquet` with columns `ticker`, `index`,
+  `date_added`, `date_removed` (NaT = still active). Tickers that rejoined the
+  index appear as multiple rows. Addresses MD-03 of the survivorship bias audit
+  (issue #60).
+- `fetch_backfill.py`: backfills historical OHLCV data for delisted S&P 500
+  constituents. Reads `constituent_history.parquet`, finds tickers with no
+  existing OHLCV file, and fetches their full membership date range via
+  yfinance. Progress (completed/failures) is persisted to `state.json` so runs
+  are safely resumable. Supports `--batch-size` and `--dry-run`.
+- `fetch.fetch_date_range()`: bounded date-range variant of `fetch_history()`
+  used by the backfill pipeline.
+- `market-data-fetch-constituent-history` and `market-data-backfill-constituents`
+  CLI commands.
+
+---
+
 ## [0.6.3] — 2026-04-16 ([#59](https://github.com/michaelk95/market_data/pull/59))
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ virtual environment:
 | `market-data-fetch-macro` | Update FRED macro series (CPI, GDP, Fed Funds rate, Treasury spread, etc.) |
 | `market-data-fetch-fundamentals` | Snapshot per-ticker fundamentals for all onboarded tickers (market cap, analyst targets, etc.) |
 | `market-data-fetch-options` | Run the next batch of SP500 option chain snapshots (IV, bid/ask, open interest) |
+| `market-data-fetch-constituent-history` | Download historical S&P 500 constituent membership (1996–present) to `data/constituent_history.parquet` |
+| `market-data-backfill-constituents` | Backfill OHLCV data for delisted S&P 500 tickers to mitigate survivorship bias |
 
 Each command accepts `--help` for full usage details.
 
@@ -103,7 +105,44 @@ market-data-fetch-macro                 # FRED series back to 1990-01-01
 market-data-fetch-fundamentals          # current snapshot for all onboarded tickers
 ```
 
-### 6. Merge into a single file
+### 6. Mitigate survivorship bias (one-time)
+
+By default, the pipeline only tracks tickers in the **current** Russell 2000
+and S&P 500 constituents. This introduces survivorship bias: companies that
+were delisted, acquired, or removed from an index are invisible in the dataset,
+making historical backtests appear more profitable than they would have been
+in practice.
+
+To reduce this bias, run the following two commands once after initial setup:
+
+```bash
+# Step 1 — download S&P 500 constituent history (1996–present, ~1,200 tickers)
+market-data-fetch-constituent-history
+
+# Step 2 — backfill OHLCV for the ~743 delisted tickers
+# (runs in batches of 50; safe to interrupt and resume)
+market-data-backfill-constituents --batch-size 50
+market-data-backfill-constituents --batch-size 50  # re-run until "Nothing to backfill"
+```
+
+Use `--dry-run` to preview the scope before committing:
+
+```bash
+market-data-backfill-constituents --dry-run
+```
+
+**What this does:** `constituent_history.parquet` records every ticker's
+S&P 500 membership span (`date_added` → `date_removed`). For each delisted
+ticker with no existing OHLCV file, the backfill fetches that exact date range
+from yfinance and saves it to `data/ohlcv/` using the same schema as the
+regular pipeline. Progress (completed and failed tickers) is written to
+`state.json` after each ticker so the run is safely resumable.
+
+**Limitation:** yfinance has incomplete coverage for some older or
+bankruptcy-reorganised tickers. Those are recorded in `state.json` under
+`backfill_failures` and can be reviewed after the run.
+
+### 7. Merge into a single file
 
 Merge all per-ticker OHLCV files into a single Parquet for the backtest engine:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ market-data-fetch-analyst-estimates = "market_data.fetch_analyst_estimates:main"
 market-data-migrate-fundamentals = "market_data.migrate_fundamentals:main"
 market-data-migrate-macro        = "market_data.migrate_macro:main"
 market-data-fetch-options       = "market_data.fetch_options:main"
+market-data-fetch-constituent-history = "market_data.fetch_constituent_history:main"
+market-data-backfill-constituents     = "market_data.fetch_backfill:main"
 market-data-health              = "market_data.health:main"
 market-data-smoke-test          = "market_data.smoke_test:main"
 

--- a/src/market_data/fetch.py
+++ b/src/market_data/fetch.py
@@ -120,6 +120,28 @@ def fetch_incremental(symbol: str, since: date) -> pd.DataFrame:
     return _normalize(raw, symbol)
 
 
+@yf_retry
+def fetch_date_range(
+    symbol: str,
+    start: date,
+    end: date | None = None,
+) -> pd.DataFrame:
+    """Download daily OHLCV history for *symbol* from *start* to *end* inclusive.
+
+    Used by the backfill pipeline to fetch bounded membership periods for
+    delisted tickers.  Falls back to today when *end* is None.
+    """
+    if end is None:
+        end = date.today()
+    raw = yf.Ticker(symbol).history(
+        start=str(start),
+        end=str(end + timedelta(days=1)),  # yfinance end is exclusive
+        auto_adjust=True,
+        actions=False,
+    )
+    return _normalize(raw, symbol)
+
+
 def load_ticker_data(symbol: str, data_dir: Path) -> pd.DataFrame | None:
     """
     Load the existing Parquet for `symbol`, or return None if it doesn't exist.

--- a/src/market_data/fetch_backfill.py
+++ b/src/market_data/fetch_backfill.py
@@ -1,0 +1,313 @@
+"""
+fetch_backfill.py
+-----------------
+Backfills historical OHLCV data for S&P 500 tickers that were delisted or
+removed from the index before the regular pipeline began tracking them.
+
+Source:  data/constituent_history.parquet   (built by fetch_constituent_history)
+Output:  data/ohlcv/<SYMBOL>.parquet        (same schema as the regular pipeline)
+
+For each delisted ticker (date_removed is not NaT) that has no existing OHLCV
+file, this module fetches the full span of its S&P 500 membership using
+yfinance and stores it via the same atomic save used by the main pipeline.
+
+Tickers with multiple membership periods (e.g. AAL: 1996→1997, 2015→2024) are
+fetched as a single request from the earliest start to the latest end; gaps
+where the stock was not traded produce no rows.
+
+Active tickers (date_removed is NaT) are intentionally skipped — they are
+managed by the normal daily pipeline.
+
+Progress state
+--------------
+Two keys are written to state.json after each run:
+
+  backfill_completed  list[str]        Tickers that produced ≥1 row of data.
+  backfill_failures   dict[str, str]   Tickers that returned no data; value is
+                                       a short reason string.
+
+Runs are safe to interrupt and resume: completed and failed tickers are skipped
+on subsequent calls.
+
+CLI: market-data-backfill-constituents
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+import time
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+
+from market_data.config import cfg as _cfg
+from market_data.fetch import fetch_date_range, save_ticker_data
+
+logger = logging.getLogger(__name__)
+
+STATE_FILE = Path(_cfg.get("paths.state_file", "state.json"))
+OHLCV_DIR = Path(_cfg.get("paths.ohlcv_dir", "data/ohlcv"))
+CONSTITUENT_HISTORY_FILE = _cfg.resolve_path(
+    "paths.constituent_history_file", "data/constituent_history.parquet"
+)
+
+DEFAULT_BATCH_SIZE: int = _cfg.get("collection.backfill_batch_size", 50)
+SLEEP_BETWEEN_CALLS: float = _cfg.get("sources.sleep_between_calls.ohlcv", 5)
+
+
+# ---------------------------------------------------------------------------
+# State helpers (mirrors orchestrator pattern)
+# ---------------------------------------------------------------------------
+
+def _load_state() -> dict:
+    if STATE_FILE.exists():
+        raw = json.loads(STATE_FILE.read_text())
+    else:
+        raw = {}
+    return {
+        "backfill_completed": raw.get("backfill_completed", []),
+        "backfill_failures": raw.get("backfill_failures", {}),
+        **{k: v for k, v in raw.items()
+           if k not in {"backfill_completed", "backfill_failures"}},
+    }
+
+
+def _save_state(state: dict) -> None:
+    STATE_FILE.write_text(json.dumps(state, indent=2, default=str))
+
+
+# ---------------------------------------------------------------------------
+# Pending-ticker logic
+# ---------------------------------------------------------------------------
+
+def pending_tickers(
+    constituent_df: pd.DataFrame,
+    ohlcv_dir: Path,
+    completed: set[str],
+    failures: set[str],
+) -> list[dict]:
+    """Return backfill jobs for delisted tickers that have no OHLCV file yet.
+
+    Each entry is a dict with keys: ticker, start (date), end (date).
+
+    Skips:
+    - Active tickers (date_removed is NaT) — handled by the normal pipeline.
+    - Tickers already in *completed* or *failures*.
+    - Tickers that already have a file under *ohlcv_dir* (assumed covered).
+
+    For tickers with multiple membership periods, start/end span the full
+    range (earliest date_added → latest date_removed).
+    """
+    delisted = constituent_df[constituent_df["date_removed"].notna()].copy()
+
+    # Collapse multiple periods per ticker into a single date range
+    grouped = (
+        delisted.groupby("ticker")
+        .agg(start=("date_added", "min"), end=("date_removed", "max"))
+        .reset_index()
+    )
+
+    jobs = []
+    for row in grouped.itertuples(index=False):
+        ticker = row.ticker
+        if ticker in completed or ticker in failures:
+            continue
+        if (ohlcv_dir / f"{ticker}.parquet").exists():
+            continue
+        jobs.append({
+            "ticker": ticker,
+            "start": row.start.date() if hasattr(row.start, "date") else row.start,
+            "end": row.end.date() if hasattr(row.end, "date") else row.end,
+        })
+
+    return jobs
+
+
+# ---------------------------------------------------------------------------
+# Main backfill runner
+# ---------------------------------------------------------------------------
+
+def run(
+    constituent_path: Path = CONSTITUENT_HISTORY_FILE,
+    ohlcv_dir: Path = OHLCV_DIR,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    dry_run: bool = False,
+) -> dict:
+    """Backfill OHLCV for delisted S&P 500 tickers.
+
+    Parameters
+    ----------
+    constituent_path:
+        Path to constituent_history.parquet.
+    ohlcv_dir:
+        Directory where per-ticker OHLCV parquets are stored.
+    batch_size:
+        Maximum number of tickers to fetch in a single run (0 = no limit).
+    dry_run:
+        If True, log what would be fetched without making any network calls
+        or writing any files.
+
+    Returns
+    -------
+    dict with keys ``fetched``, ``skipped``, ``failed``, ``remaining``.
+    """
+    if not constituent_path.exists():
+        raise FileNotFoundError(
+            f"Constituent history not found at {constituent_path}. "
+            "Run market-data-fetch-constituent-history first."
+        )
+
+    constituent_df = pd.read_parquet(constituent_path)
+    state = _load_state()
+    completed: set[str] = set(state["backfill_completed"])
+    failures: set[str] = set(state["backfill_failures"].keys())
+
+    jobs = pending_tickers(constituent_df, ohlcv_dir, completed, failures)
+
+    total_delisted = constituent_df["date_removed"].notna().sum()
+    skipped_existing = total_delisted - len(jobs) - len(failures)
+
+    logger.info(
+        "Backfill summary: %d delisted tickers total | "
+        "%d already complete or have OHLCV file | %d failed previously | "
+        "%d pending",
+        total_delisted, int(skipped_existing) + len(completed), len(failures), len(jobs),
+    )
+
+    if not jobs:
+        logger.info("Nothing to backfill.")
+        return {"fetched": 0, "skipped": int(skipped_existing), "failed": 0, "remaining": 0}
+
+    if batch_size > 0:
+        batch = jobs[:batch_size]
+        remaining = len(jobs) - len(batch)
+    else:
+        batch = jobs
+        remaining = 0
+
+    logger.info(
+        "Processing %d tickers this run%s%s.",
+        len(batch),
+        f" (batch_size={batch_size})" if batch_size > 0 else "",
+        " [DRY RUN]" if dry_run else "",
+    )
+
+    fetched = failed = 0
+
+    for i, job in enumerate(batch, 1):
+        ticker = job["ticker"]
+        start = job["start"]
+        end = job["end"]
+
+        if dry_run:
+            logger.info(
+                "  [dry-run] %d/%d  %s  %s → %s",
+                i, len(batch), ticker, start, end,
+            )
+            continue
+
+        logger.info(
+            "  %d/%d  %s  %s → %s",
+            i, len(batch), ticker, start, end,
+        )
+
+        try:
+            df = fetch_date_range(ticker, start, end)
+        except Exception as exc:  # noqa: BLE001
+            reason = str(exc)[:200]
+            logger.warning("    FAIL %s: %s", ticker, reason)
+            state["backfill_failures"][ticker] = reason
+            failed += 1
+            _save_state(state)
+            continue
+
+        if df.empty:
+            reason = "no data returned by yfinance"
+            logger.warning("    SKIP %s: %s", ticker, reason)
+            state["backfill_failures"][ticker] = reason
+            failed += 1
+            _save_state(state)
+            continue
+
+        new_rows = save_ticker_data(ticker, df, ohlcv_dir)
+        logger.info("    OK   %s: %d rows (%d new)", ticker, len(df), new_rows)
+        state["backfill_completed"].append(ticker)
+        fetched += 1
+        _save_state(state)
+
+        if i < len(batch):
+            time.sleep(SLEEP_BETWEEN_CALLS)
+
+    if not dry_run:
+        logger.info(
+            "Backfill run complete: %d fetched, %d failed, %d remaining.",
+            fetched, failed, remaining,
+        )
+
+    return {
+        "fetched": fetched,
+        "skipped": int(skipped_existing),
+        "failed": failed,
+        "remaining": remaining,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    from market_data.logging_config import setup_logging  # noqa: PLC0415
+    setup_logging()
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Backfill historical OHLCV for delisted S&P 500 constituents. "
+            "Reads data/constituent_history.parquet and writes to data/ohlcv/."
+        )
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=DEFAULT_BATCH_SIZE,
+        help=(
+            f"Max tickers to fetch per run (default: {DEFAULT_BATCH_SIZE}; "
+            "0 = no limit)"
+        ),
+    )
+    parser.add_argument(
+        "--history-file",
+        default=None,
+        help="Path to constituent_history.parquet (default: data/constituent_history.parquet)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Log what would be fetched without making network calls.",
+    )
+    args = parser.parse_args()
+
+    constituent_path = (
+        Path(args.history_file) if args.history_file else CONSTITUENT_HISTORY_FILE
+    )
+
+    try:
+        run(
+            constituent_path=constituent_path,
+            batch_size=args.batch_size,
+            dry_run=args.dry_run,
+        )
+    except FileNotFoundError as exc:
+        logger.error("%s", exc)
+        sys.exit(1)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Backfill failed: %s", exc, exc_info=True)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/market_data/fetch_backfill.py
+++ b/src/market_data/fetch_backfill.py
@@ -39,7 +39,6 @@ import json
 import logging
 import sys
 import time
-from datetime import date
 from pathlib import Path
 
 import pandas as pd

--- a/src/market_data/fetch_constituent_history.py
+++ b/src/market_data/fetch_constituent_history.py
@@ -1,0 +1,162 @@
+"""
+fetch_constituent_history.py
+----------------------------
+Downloads and stores historical S&P 500 constituent membership.
+
+Source: fja05680/sp500 on GitHub (MIT licence)
+  sp500_ticker_start_end.csv — one row per ticker per membership period,
+  with columns: ticker, start_date, end_date (empty = still active).
+  Tickers that rejoined the index after being removed appear as multiple rows.
+
+  URL: https://raw.githubusercontent.com/fja05680/sp500/refs/heads/master/
+       sp500_ticker_start_end.csv
+
+Russell 2000 historical constituent data has no free structured source
+and is not collected here.  Add when a reliable source is identified.
+
+Output: data/constituent_history.parquet
+  Schema:
+    ticker        str           yfinance-compatible symbol
+    index         str           "SP500"
+    date_added    datetime64    date ticker entered the index
+    date_removed  datetime64    date ticker left the index; NaT = still active
+
+  Note: a ticker may appear more than once when it left and later rejoined
+  the index (e.g. AAL: 1996-01-02→1997-01-15, then 2015-03-23→2024-09-23).
+
+CLI:  market-data-fetch-constituent-history
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import logging
+import sys
+from pathlib import Path
+
+import pandas as pd
+import requests
+
+from market_data.config import cfg
+from market_data.resilience import requests_retry
+
+logger = logging.getLogger(__name__)
+
+_TICKER_START_END_URL = (
+    "https://raw.githubusercontent.com/fja05680/sp500/refs/heads/master/"
+    "sp500_ticker_start_end.csv"
+)
+
+
+@requests_retry
+def _fetch_raw() -> str:
+    """Download sp500_ticker_start_end.csv and return the raw text."""
+    resp = requests.get(_TICKER_START_END_URL, timeout=30)
+    resp.raise_for_status()
+    return resp.text
+
+
+def parse_ticker_start_end(raw: str) -> pd.DataFrame:
+    """Parse the sp500_ticker_start_end CSV into the constituent history schema.
+
+    Parameters
+    ----------
+    raw:
+        Raw CSV text from the fja05680 dataset.
+
+    Returns
+    -------
+    DataFrame with columns: ticker, index, date_added, date_removed.
+    Rows are sorted by ticker then date_added.  Tickers that rejoined the
+    index appear as separate rows.
+    """
+    df = pd.read_csv(io.StringIO(raw), dtype=str)
+    df.columns = [c.strip() for c in df.columns]
+
+    required = {"ticker", "start_date", "end_date"}
+    missing = required - set(df.columns)
+    if missing:
+        raise ValueError(
+            f"Expected columns {required}; missing {missing}. "
+            f"Got: {df.columns.tolist()}"
+        )
+
+    df["ticker"] = df["ticker"].str.strip()
+    df = df[df["ticker"].notna() & (df["ticker"] != "")].copy()
+
+    df["date_added"] = pd.to_datetime(
+        df["start_date"].str.strip(), format="ISO8601", errors="coerce"
+    )
+    # Empty end_date means the ticker is still active → NaT
+    df["date_removed"] = pd.to_datetime(
+        df["end_date"].str.strip().replace("", pd.NA), format="ISO8601", errors="coerce"
+    )
+
+    result = df[["ticker", "date_added", "date_removed"]].copy()
+    result.insert(1, "index", "SP500")
+    result = (
+        result.dropna(subset=["date_added"])
+        .sort_values(["ticker", "date_added"])
+        .reset_index(drop=True)
+    )
+
+    n_active = result["date_removed"].isna().sum()
+    n_delisted = result["date_removed"].notna().sum()
+    n_tickers = result["ticker"].nunique()
+    logger.info(
+        "Parsed SP500 constituent history: %d unique tickers, "
+        "%d membership periods (%d active, %d with end date)",
+        n_tickers, len(result), n_active, n_delisted,
+    )
+    return result
+
+
+def run(out_path: Path) -> pd.DataFrame:
+    """Fetch S&P 500 constituent history and write to *out_path* (parquet)."""
+    logger.info("Fetching S&P 500 constituent history from fja05680/sp500...")
+    raw = _fetch_raw()
+    df = parse_ticker_start_end(raw)
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = out_path.with_name(out_path.stem + ".tmp.parquet")
+    df.to_parquet(tmp, index=False)
+    tmp.replace(out_path)
+    logger.info("Saved %d constituent records to %s", len(df), out_path)
+    return df
+
+
+def main() -> None:
+    from market_data.logging_config import setup_logging  # noqa: PLC0415
+    setup_logging()
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Fetch S&P 500 historical constituent membership from "
+            "github.com/fja05680/sp500 and save to parquet."
+        )
+    )
+    parser.add_argument(
+        "--out",
+        default=None,
+        help="Output parquet path (default: data/constituent_history.parquet)",
+    )
+    args = parser.parse_args()
+
+    out_path = (
+        Path(args.out)
+        if args.out
+        else cfg.resolve_path(
+            "paths.constituent_history_file", "data/constituent_history.parquet"
+        )
+    )
+
+    try:
+        run(out_path)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Failed to fetch constituent history: %s", exc, exc_info=True)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_fetch_backfill.py
+++ b/tests/test_fetch_backfill.py
@@ -1,0 +1,270 @@
+"""
+Tests for fetch_backfill.py:
+  - pending_tickers()  — skipping logic (completed, failures, existing files,
+                          active tickers, multi-period collapse)
+  - run()              — fetch/save orchestration, state persistence, dry-run,
+                          empty-data handling
+"""
+
+import json
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pandas as pd
+import pytest
+
+from market_data.fetch_backfill import pending_tickers, run
+
+
+# ---------------------------------------------------------------------------
+# Fixtures & helpers
+# ---------------------------------------------------------------------------
+
+def _hist(tickers_and_periods: list[tuple]) -> pd.DataFrame:
+    """Build a minimal constituent_history DataFrame."""
+    rows = []
+    for ticker, date_added, date_removed in tickers_and_periods:
+        rows.append({
+            "ticker": ticker,
+            "index": "SP500",
+            "date_added": pd.Timestamp(date_added),
+            "date_removed": pd.Timestamp(date_removed) if date_removed else pd.NaT,
+        })
+    return pd.DataFrame(rows)
+
+
+def _ohlcv(ticker: str, n: int = 5) -> pd.DataFrame:
+    """Return a minimal OHLCV DataFrame for a ticker."""
+    dates = pd.date_range("2000-01-03", periods=n, freq="B").date
+    return pd.DataFrame({
+        "date": dates,
+        "symbol": ticker,
+        "open": 100.0,
+        "high": 105.0,
+        "low": 95.0,
+        "close": 102.0,
+        "volume": 1_000_000.0,
+    })
+
+
+# ---------------------------------------------------------------------------
+# pending_tickers()
+# ---------------------------------------------------------------------------
+
+class TestPendingTickers:
+    def test_delisted_ticker_with_no_file_is_pending(self, tmp_path):
+        hist = _hist([("DEAD", "2000-01-01", "2010-06-15")])
+        jobs = pending_tickers(hist, tmp_path, set(), set())
+        assert len(jobs) == 1
+        assert jobs[0]["ticker"] == "DEAD"
+
+    def test_active_ticker_is_skipped(self, tmp_path):
+        hist = _hist([("AAPL", "2000-01-01", None)])
+        jobs = pending_tickers(hist, tmp_path, set(), set())
+        assert jobs == []
+
+    def test_completed_ticker_is_skipped(self, tmp_path):
+        hist = _hist([("DEAD", "2000-01-01", "2010-06-15")])
+        jobs = pending_tickers(hist, tmp_path, {"DEAD"}, set())
+        assert jobs == []
+
+    def test_failed_ticker_is_skipped(self, tmp_path):
+        hist = _hist([("DEAD", "2000-01-01", "2010-06-15")])
+        jobs = pending_tickers(hist, tmp_path, set(), {"DEAD"})
+        assert jobs == []
+
+    def test_ticker_with_existing_file_is_skipped(self, tmp_path):
+        hist = _hist([("DEAD", "2000-01-01", "2010-06-15")])
+        (tmp_path / "DEAD.parquet").touch()
+        jobs = pending_tickers(hist, tmp_path, set(), set())
+        assert jobs == []
+
+    def test_date_range_uses_earliest_start_latest_end(self, tmp_path):
+        # Ticker with two membership periods
+        hist = _hist([
+            ("AAL", "1996-01-02", "1997-01-15"),
+            ("AAL", "2015-03-23", "2024-09-23"),
+        ])
+        jobs = pending_tickers(hist, tmp_path, set(), set())
+        assert len(jobs) == 1
+        assert jobs[0]["start"] == date(1996, 1, 2)
+        assert jobs[0]["end"] == date(2024, 9, 23)
+
+    def test_multiple_pending_tickers_all_returned(self, tmp_path):
+        hist = _hist([
+            ("DEAD1", "2000-01-01", "2010-01-01"),
+            ("DEAD2", "2005-01-01", "2015-01-01"),
+            ("ALIVE", "2000-01-01", None),
+        ])
+        jobs = pending_tickers(hist, tmp_path, set(), set())
+        tickers = {j["ticker"] for j in jobs}
+        assert tickers == {"DEAD1", "DEAD2"}
+
+    def test_job_contains_correct_date_fields(self, tmp_path):
+        hist = _hist([("DEAD", "2003-07-14", "2018-11-30")])
+        jobs = pending_tickers(hist, tmp_path, set(), set())
+        assert jobs[0]["start"] == date(2003, 7, 14)
+        assert jobs[0]["end"] == date(2018, 11, 30)
+
+
+# ---------------------------------------------------------------------------
+# run()
+# ---------------------------------------------------------------------------
+
+class TestRun:
+    @pytest.fixture()
+    def hist_file(self, tmp_path) -> Path:
+        df = _hist([
+            ("DEAD1", "2000-01-01", "2010-06-15"),
+            ("DEAD2", "2005-01-01", "2015-03-01"),
+        ])
+        path = tmp_path / "constituent_history.parquet"
+        df.to_parquet(path, index=False)
+        return path
+
+    @pytest.fixture()
+    def state_file(self, tmp_path) -> Path:
+        return tmp_path / "state.json"
+
+    @patch("market_data.fetch_backfill.fetch_date_range")
+    @patch("market_data.fetch_backfill.save_ticker_data")
+    @patch("market_data.fetch_backfill.STATE_FILE")
+    def test_fetches_and_saves_pending_tickers(
+        self, mock_state_path, mock_save, mock_fetch, hist_file, tmp_path, state_file
+    ):
+        mock_state_path.__str__ = lambda s: str(state_file)
+        mock_state_path.exists.return_value = False
+        mock_state_path.write_text = state_file.write_text
+        mock_fetch.return_value = _ohlcv("DEAD1")
+        mock_save.return_value = 5
+
+        result = run(
+            constituent_path=hist_file,
+            ohlcv_dir=tmp_path / "ohlcv",
+            batch_size=0,
+            dry_run=False,
+        )
+
+        assert mock_fetch.call_count == 2
+        assert result["fetched"] == 2
+        assert result["failed"] == 0
+
+    @patch("market_data.fetch_backfill.fetch_date_range")
+    @patch("market_data.fetch_backfill.save_ticker_data")
+    @patch("market_data.fetch_backfill.STATE_FILE")
+    def test_batch_size_limits_fetches(
+        self, mock_state_path, mock_save, mock_fetch, hist_file, tmp_path, state_file
+    ):
+        mock_state_path.exists.return_value = False
+        mock_state_path.write_text = state_file.write_text
+        mock_fetch.return_value = _ohlcv("DEAD1")
+        mock_save.return_value = 5
+
+        result = run(
+            constituent_path=hist_file,
+            ohlcv_dir=tmp_path / "ohlcv",
+            batch_size=1,
+            dry_run=False,
+        )
+
+        assert mock_fetch.call_count == 1
+        assert result["fetched"] == 1
+        assert result["remaining"] == 1
+
+    @patch("market_data.fetch_backfill.fetch_date_range")
+    @patch("market_data.fetch_backfill.save_ticker_data")
+    @patch("market_data.fetch_backfill.STATE_FILE")
+    def test_empty_data_recorded_as_failure(
+        self, mock_state_path, mock_save, mock_fetch, hist_file, tmp_path, state_file
+    ):
+        mock_state_path.exists.return_value = False
+        mock_state_path.write_text = state_file.write_text
+        mock_fetch.return_value = pd.DataFrame()  # yfinance returned nothing
+
+        result = run(
+            constituent_path=hist_file,
+            ohlcv_dir=tmp_path / "ohlcv",
+            batch_size=0,
+            dry_run=False,
+        )
+
+        assert result["failed"] == 2
+        assert result["fetched"] == 0
+        mock_save.assert_not_called()
+
+    @patch("market_data.fetch_backfill.fetch_date_range")
+    @patch("market_data.fetch_backfill.save_ticker_data")
+    @patch("market_data.fetch_backfill.STATE_FILE")
+    def test_dry_run_makes_no_network_calls(
+        self, mock_state_path, mock_save, mock_fetch, hist_file, tmp_path, state_file
+    ):
+        mock_state_path.exists.return_value = False
+        mock_state_path.write_text = state_file.write_text
+
+        run(
+            constituent_path=hist_file,
+            ohlcv_dir=tmp_path / "ohlcv",
+            batch_size=0,
+            dry_run=True,
+        )
+
+        mock_fetch.assert_not_called()
+        mock_save.assert_not_called()
+
+    def test_missing_constituent_file_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError, match="market-data-fetch-constituent-history"):
+            run(constituent_path=tmp_path / "nonexistent.parquet")
+
+    @patch("market_data.fetch_backfill.fetch_date_range")
+    @patch("market_data.fetch_backfill.save_ticker_data")
+    @patch("market_data.fetch_backfill.STATE_FILE")
+    def test_completed_tickers_persisted_to_state(
+        self, mock_state_path, mock_save, mock_fetch, hist_file, tmp_path, state_file
+    ):
+        written = {}
+
+        def _write(text):
+            written["state"] = json.loads(text)
+
+        mock_state_path.exists.return_value = False
+        mock_state_path.write_text = _write
+        mock_fetch.return_value = _ohlcv("DEAD1")
+        mock_save.return_value = 5
+
+        run(
+            constituent_path=hist_file,
+            ohlcv_dir=tmp_path / "ohlcv",
+            batch_size=0,
+            dry_run=False,
+        )
+
+        assert "DEAD1" in written["state"]["backfill_completed"]
+        assert "DEAD2" in written["state"]["backfill_completed"]
+
+    @patch("market_data.fetch_backfill.fetch_date_range")
+    @patch("market_data.fetch_backfill.save_ticker_data")
+    @patch("market_data.fetch_backfill.STATE_FILE")
+    def test_existing_ohlcv_file_skipped(
+        self, mock_state_path, mock_save, mock_fetch, hist_file, tmp_path, state_file
+    ):
+        ohlcv_dir = tmp_path / "ohlcv"
+        ohlcv_dir.mkdir()
+        (ohlcv_dir / "DEAD1.parquet").touch()
+
+        mock_state_path.exists.return_value = False
+        mock_state_path.write_text = state_file.write_text
+        mock_fetch.return_value = _ohlcv("DEAD2")
+        mock_save.return_value = 5
+
+        result = run(
+            constituent_path=hist_file,
+            ohlcv_dir=ohlcv_dir,
+            batch_size=0,
+            dry_run=False,
+        )
+
+        assert result["fetched"] == 1
+        fetched_tickers = [c.args[0] for c in mock_fetch.call_args_list]
+        assert "DEAD1" not in fetched_tickers
+        assert "DEAD2" in fetched_tickers

--- a/tests/test_fetch_backfill.py
+++ b/tests/test_fetch_backfill.py
@@ -9,7 +9,7 @@ Tests for fetch_backfill.py:
 import json
 from datetime import date
 from pathlib import Path
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import patch
 
 import pandas as pd
 import pytest

--- a/tests/test_fetch_constituent_history.py
+++ b/tests/test_fetch_constituent_history.py
@@ -1,0 +1,128 @@
+"""
+Tests for fetch_constituent_history.py:
+  - parse_ticker_start_end() — column mapping, date parsing, active/removed
+                               distinction, multi-period tickers
+"""
+
+import textwrap
+
+import pandas as pd
+import pytest
+
+from market_data.fetch_constituent_history import parse_ticker_start_end
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _csv(*rows: str) -> str:
+    """Build a minimal sp500_ticker_start_end CSV string."""
+    header = "ticker,start_date,end_date"
+    return header + "\n" + "\n".join(rows)
+
+
+# ---------------------------------------------------------------------------
+# parse_ticker_start_end()
+# ---------------------------------------------------------------------------
+
+class TestParseTickerStartEnd:
+    def test_output_columns(self):
+        raw = _csv("AAPL,2000-01-01,")
+        result = parse_ticker_start_end(raw)
+        assert list(result.columns) == ["ticker", "index", "date_added", "date_removed"]
+
+    def test_index_column_is_sp500(self):
+        raw = _csv("AAPL,2000-01-01,", "MSFT,1999-01-01,")
+        result = parse_ticker_start_end(raw)
+        assert (result["index"] == "SP500").all()
+
+    def test_active_ticker_has_nat_date_removed(self):
+        raw = _csv("AAPL,2000-01-01,")
+        result = parse_ticker_start_end(raw)
+        assert pd.isna(result.loc[0, "date_removed"])
+
+    def test_removed_ticker_has_date_removed(self):
+        raw = _csv("DEAD,2000-01-01,2010-06-15")
+        result = parse_ticker_start_end(raw)
+        assert result.loc[0, "date_removed"] == pd.Timestamp("2010-06-15")
+
+    def test_date_added_parsed(self):
+        raw = _csv("AAPL,1976-03-01,")
+        result = parse_ticker_start_end(raw)
+        assert result.loc[0, "date_added"] == pd.Timestamp("1976-03-01")
+
+    def test_multi_period_ticker_produces_multiple_rows(self):
+        # AAL left and rejoined — should produce 2 rows
+        raw = _csv(
+            "AAL,1996-01-02,1997-01-15",
+            "AAL,2015-03-23,2024-09-23",
+        )
+        result = parse_ticker_start_end(raw)
+        aal = result[result["ticker"] == "AAL"]
+        assert len(aal) == 2
+        assert aal.iloc[0]["date_added"] == pd.Timestamp("1996-01-02")
+        assert aal.iloc[1]["date_added"] == pd.Timestamp("2015-03-23")
+
+    def test_sorted_by_ticker_then_date(self):
+        raw = _csv(
+            "MSFT,1999-01-01,",
+            "AAPL,2000-01-01,",
+            "AAPL,1997-01-01,1999-12-31",
+        )
+        result = parse_ticker_start_end(raw)
+        assert list(result["ticker"]) == ["AAPL", "AAPL", "MSFT"]
+        aapl = result[result["ticker"] == "AAPL"]
+        assert aapl.iloc[0]["date_added"] < aapl.iloc[1]["date_added"]
+
+    def test_strips_whitespace_from_tickers(self):
+        raw = _csv("  AAPL  ,2000-01-01,")
+        result = parse_ticker_start_end(raw)
+        assert result.loc[0, "ticker"] == "AAPL"
+
+    def test_strips_whitespace_from_column_names(self):
+        raw = " ticker , start_date , end_date \nAAPL,2000-01-01,"
+        result = parse_ticker_start_end(raw)
+        assert result.loc[0, "ticker"] == "AAPL"
+
+    def test_filters_empty_tickers(self):
+        raw = _csv("AAPL,2000-01-01,", ",2001-01-01,", "MSFT,1999-01-01,")
+        result = parse_ticker_start_end(raw)
+        assert set(result["ticker"]) == {"AAPL", "MSFT"}
+
+    def test_drops_rows_with_unparseable_date_added(self):
+        raw = _csv("AAPL,not-a-date,", "MSFT,2000-01-01,")
+        result = parse_ticker_start_end(raw)
+        assert list(result["ticker"]) == ["MSFT"]
+
+    def test_missing_required_column_raises(self):
+        raw = "symbol,start_date,end_date\nAAPL,2000-01-01,"
+        with pytest.raises(ValueError, match="missing"):
+            parse_ticker_start_end(raw)
+
+    def test_mixed_active_and_removed(self):
+        raw = _csv(
+            "AAPL,2000-01-01,",
+            "DEAD,2005-01-01,2015-06-01",
+            "MSFT,1999-01-01,",
+        )
+        result = parse_ticker_start_end(raw)
+        assert result["date_removed"].isna().sum() == 2   # AAPL and MSFT
+        assert result["date_removed"].notna().sum() == 1  # DEAD
+
+    def test_real_format_sample(self):
+        """Parse a sample that mirrors the actual fja05680 CSV format."""
+        raw = textwrap.dedent("""\
+            ticker,start_date,end_date
+            A,2000-06-05,
+            AABA,1999-12-08,2017-06-19
+            AAL,1996-01-02,1997-01-15
+            AAL,2015-03-23,2024-09-23
+            AAPL,1996-01-02,
+        """)
+        result = parse_ticker_start_end(raw)
+        assert len(result) == 5
+        assert result["ticker"].nunique() == 4
+        assert result[result["ticker"] == "AAPL"]["date_removed"].isna().all()
+        aaba = result[result["ticker"] == "AABA"].iloc[0]
+        assert aaba["date_removed"] == pd.Timestamp("2017-06-19")


### PR DESCRIPTION
## Summary

- Adds `fetch_constituent_history.py` — downloads S&P 500 membership history (1996–present) from [fja05680/sp500](https://github.com/fja05680/sp500) (`sp500_ticker_start_end.csv`) and writes `data/constituent_history.parquet` with columns `ticker`, `index`, `date_added`, `date_removed`. Tickers that rejoined the index appear as multiple rows (e.g. AAL: 1996→1997, 2015→2024).
- Adds `fetch_backfill.py` — reads `constituent_history.parquet`, finds the ~743 delisted tickers with no existing OHLCV file, and fetches their full membership date range via yfinance. Progress is persisted to `state.json` so runs are safely resumable with `--batch-size`.
- Adds `fetch.fetch_date_range()` — bounded date-range variant of `fetch_history()` used by the backfill.
- Adds `market-data-fetch-constituent-history` and `market-data-backfill-constituents` CLI commands.
- Updates README with survivorship bias mitigation section and usage examples.

Closes #60 (MD-03, Phase 1 + Phase 2).

## Test plan

- [ ] `pytest tests/test_fetch_constituent_history.py` — 14 tests covering CSV parsing, column mapping, multi-period tickers, edge cases
- [ ] `pytest tests/test_fetch_backfill.py` — 15 tests covering skip logic, batch sizing, dry-run, state persistence, empty-data handling
- [ ] `market-data-fetch-constituent-history` — verify `data/constituent_history.parquet` written (1,246 rows, 1,194 unique tickers)
- [ ] `market-data-backfill-constituents --dry-run` — verify ~743 pending tickers logged with correct date ranges
- [ ] `market-data-backfill-constituents --batch-size 5` — verify 5 parquet files written to `data/ohlcv/` and state persisted to `state.json`