### PR TITLE
fix: handle ALFRED-not-found errors with per-chunk skip and get_series fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ All notable changes to this project will be documented here.
 ### Fixed
 - `fetch_macro`: chunked `get_series_all_releases` calls into 4-year windows to stay under FRED's 2000-vintage-date-per-request limit (was causing HTTP 400 for DFF and T10Y2Y on bootstrap and long lookback windows).
 - `fetch_macro`: derived `realtime_end` / `valid_to_date` from the vintage chain instead of reading it from the fredapi response (fredapi never returned that column).
-- `fetch_macro`: ALFRED chunks that return "does not exist in ALFRED" are now skipped; if all chunks fail (series has no vintage history, e.g. DFF, T10Y2Y), falls back to a plain `fred.get_series()` call and stores current values with a synthetic `report_date` of today.
+- `fetch_macro`: ALFRED chunks that return "does not exist in ALFRED" are now skipped silently, so series whose ALFRED coverage starts after the bootstrap date (e.g. CPILFESL, PCEPI) still collect whatever vintage history is available. If every chunk fails this way, the fetcher falls back to a plain `fred.get_series()` call — these series (e.g. DFF, T10Y2Y) are daily market rates that are never revised, so no vintage history exists and storing current values is correct. Rows fetched via the fallback carry `report_date = today` and `valid_to_date = 9999-12-31`.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented here.
 
 ---
 
+## [0.7.3] — 2026-04-18 ([#63](https://github.com/michaelk95/market_data/issues/63))
+
+### Fixed
+- `fetch_macro`: ALFRED chunks that return "does not exist in ALFRED" are now skipped silently, so series whose ALFRED coverage starts after the bootstrap date (e.g. CPILFESL, PCEPI) still collect whatever vintage history is available. If every chunk fails this way, the fetcher falls back to a plain `fred.get_series()` call — these series (e.g. DFF, T10Y2Y) are daily market rates that are never revised, so no vintage history exists and storing current values is correct. Rows fetched via the fallback carry `report_date = today` and `valid_to_date = 9999-12-31`.
+
+---
+
 ## [0.7.2] — 2026-04-17 ([#65](https://github.com/michaelk95/market_data/pull/65))
 
 ### Added
@@ -30,6 +37,7 @@ All notable changes to this project will be documented here.
 ### Fixed
 - `fetch_macro`: chunked `get_series_all_releases` calls into 4-year windows to stay under FRED's 2000-vintage-date-per-request limit (was causing HTTP 400 for DFF and T10Y2Y on bootstrap and long lookback windows).
 - `fetch_macro`: derived `realtime_end` / `valid_to_date` from the vintage chain instead of reading it from the fredapi response (fredapi never returned that column).
+- `fetch_macro`: ALFRED chunks that return "does not exist in ALFRED" are now skipped; if all chunks fail (series has no vintage history, e.g. DFF, T10Y2Y), falls back to a plain `fred.get_series()` call and stores current values with a synthetic `report_date` of today.
 
 ---
 

--- a/src/market_data/fetch_macro.py
+++ b/src/market_data/fetch_macro.py
@@ -191,6 +191,9 @@ def _derive_realtime_end(df: pd.DataFrame) -> pd.Series:
     )
 
 
+_ALFRED_NOT_FOUND = "does not exist in ALFRED"
+
+
 def _fetch_all_releases_chunked(
     fred: object,
     series_id: str,
@@ -200,11 +203,20 @@ def _fetch_all_releases_chunked(
     """
     Call get_series_all_releases in 4-year windows to stay under FRED's 2000
     vintage-date-per-request limit. Results are concatenated and deduplicated.
+
+    Some series exist in FRED but not in ALFRED (the vintage archive) — either
+    because they are never revised (e.g. daily market rates) or because their
+    ALFRED history starts later than our chunk window. Chunks that return an
+    "does not exist in ALFRED" error are skipped silently; if every chunk fails
+    this way the function falls back to a plain fred.get_series() call, which
+    returns current-only data with a synthetic report_date of today.
     """
     start = date.fromisoformat(realtime_start)
     end = date.fromisoformat(realtime_end)
 
     frames: list[pd.DataFrame] = []
+    total_chunks = 0
+    alfred_skipped = 0
     chunk_start = start
     while chunk_start <= end:
         try:
@@ -217,23 +229,46 @@ def _fetch_all_releases_chunked(
             chunk_end = date(chunk_start.year + _VINTAGE_CHUNK_YEARS, 2, 28)
         chunk_end = min(chunk_end, end)
 
-        raw = fred.get_series_all_releases(  # type: ignore[union-attr]
-            series_id,
-            realtime_start=str(chunk_start),
-            realtime_end=str(chunk_end),
-        )
-        if raw is not None and not (hasattr(raw, "empty") and raw.empty):
-            frames.append(raw)
+        total_chunks += 1
+        try:
+            raw = fred.get_series_all_releases(  # type: ignore[union-attr]
+                series_id,
+                realtime_start=str(chunk_start),
+                realtime_end=str(chunk_end),
+            )
+            if raw is not None and not (hasattr(raw, "empty") and raw.empty):
+                frames.append(raw)
+        except ValueError as exc:
+            if _ALFRED_NOT_FOUND in str(exc):
+                alfred_skipped += 1
+            else:
+                raise
         chunk_start = chunk_end + timedelta(days=1)
 
-    if not frames:
-        return pd.DataFrame()
+    if frames:
+        return (
+            pd.concat(frames, ignore_index=True)
+            .drop_duplicates(subset=["realtime_start", "date"])
+            .reset_index(drop=True)
+        )
 
-    return (
-        pd.concat(frames, ignore_index=True)
-        .drop_duplicates(subset=["realtime_start", "date"])
-        .reset_index(drop=True)
-    )
+    if alfred_skipped == total_chunks:
+        # Series not in ALFRED — fall back to current-only FRED fetch (no revision history)
+        logger.warning(
+            "%s  not in ALFRED; fetching current values only (no vintage/revision history)",
+            series_id,
+        )
+        raw = fred.get_series(series_id, observation_start=realtime_start)  # type: ignore[union-attr]
+        if raw is None or (hasattr(raw, "empty") and raw.empty):
+            return pd.DataFrame()
+        today = date.today()
+        return pd.DataFrame({
+            "realtime_start": today,
+            "date": raw.index,
+            "value": raw.values,
+        })
+
+    return pd.DataFrame()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_fetch_macro.py
+++ b/tests/test_fetch_macro.py
@@ -261,6 +261,39 @@ class TestFetchAllReleasesChunked:
             chunk_end = call.kwargs.get("realtime_end") or call.args[2]
             assert chunk_end <= overall_end
 
+    def test_falls_back_to_get_series_when_all_chunks_not_in_alfred(self):
+        """If every chunk returns 'not in ALFRED', fall back to fred.get_series()."""
+        fred = MagicMock()
+        fred.get_series_all_releases.side_effect = ValueError(
+            "Bad Request.  The series does not exist in ALFRED but may exist in FRED."
+        )
+        fred.get_series.return_value = pd.Series(
+            [1.5, 1.6],
+            index=pd.to_datetime(["2024-01-01", "2024-01-02"]),
+        )
+        result = _fetch_all_releases_chunked(fred, "DFF", "2024-01-01", "2024-01-02")
+        fred.get_series.assert_called_once()
+        assert len(result) == 2
+        assert "realtime_start" in result.columns
+        assert "date" in result.columns
+        assert "value" in result.columns
+
+    def test_skips_alfred_missing_chunks_and_returns_successful_ones(self):
+        """Chunks that return 'not in ALFRED' are skipped; successful chunks are kept."""
+        call_count = 0
+        def side_effect(series_id, realtime_start, realtime_end):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise ValueError("The series does not exist in ALFRED but may exist in FRED.")
+            return _VINTAGE_DF.copy()
+
+        fred = MagicMock()
+        fred.get_series_all_releases.side_effect = side_effect
+        result = _fetch_all_releases_chunked(fred, "CPILFESL", "2020-01-01", "2028-01-01")
+        assert not result.empty
+        assert fred.get_series.call_count == 0  # fallback not triggered
+
 
 # ---------------------------------------------------------------------------
 # TestUpdateSeries


### PR DESCRIPTION
Follow-up to #64 (merged).

## Problem

After #64 landed, the next run revealed a new failure mode: `get_series_all_releases` with an explicit `realtime_end` on the first chunk routes to ALFRED (the archival vintage database), and ALFRED returns HTTP 400 "series does not exist in ALFRED" for two categories of series:

1. **No ALFRED coverage at all** (DFF, T10Y2Y) — daily market rates that are never revised have no vintage history and were never archived in ALFRED.
2. **Partial ALFRED coverage** (CPILFESL, PCEPI, PCEPILFE) — ALFRED history for these series starts later than our 1990-01-01 bootstrap date, so the first 4-year chunk falls outside their ALFRED window and fails.

## Fix

In `_fetch_all_releases_chunked`:

- Each chunk's `get_series_all_releases` call is now wrapped in a `try/except ValueError`. If the error message contains `"does not exist in ALFRED"`, the chunk is skipped and the loop continues.
- If **some** chunks succeed (partial ALFRED coverage case): returns the collected frames — whatever vintage data ALFRED has is kept.
- If **all** chunks fail with this error (no ALFRED coverage at all): falls back to `fred.get_series(series_id, observation_start=realtime_start)`, which returns current values from plain FRED with no vintage params. Rows are stored with a synthetic `report_date = today` and `valid_to_date = 9999-12-31`.

## Tests

2 new cases in `TestFetchAllReleasesChunked` (44 total pass):
- `test_falls_back_to_get_series_when_all_chunks_not_in_alfred`
- `test_skips_alfred_missing_chunks_and_returns_successful_ones`