### PR TITLE
feat: extend OHLCV history to 1990 for all onboarded tickers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented here.
 
 ---
 
+## [0.8.0] — 2026-04-18 ([#PR](https://github.com/michaelk95/market_data/pull/TODO))
+
+### Added
+- `fetch_max_history()` in `fetch.py`: fetches the maximum available OHLCV
+  history for a symbol using yfinance `period="max"`.
+- `fetch_extend_history.py`: one-time backfill that extends all onboarded
+  active tickers back to 1990 (or as far as yfinance has data). For each
+  ticker, checks the earliest date on disk; if it's after 1990-01-01, fetches
+  `period="max"` and merges via `save_ticker_data` (deduplication handled
+  automatically). Tickers already at or before the target are marked complete
+  immediately — no network call. Progress (`extend_history_completed`,
+  `extend_history_failures`) is persisted to `state.json` so runs are safely
+  resumable. Supports `--batch-size` and `--dry-run`. Addresses issue #6.
+- CLI: `market-data-extend-history`
+
+---
+
 ## [0.7.2] — 2026-04-17 ([#65](https://github.com/michaelk95/market_data/pull/65))
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ market-data-migrate-macro        = "market_data.migrate_macro:main"
 market-data-fetch-options       = "market_data.fetch_options:main"
 market-data-fetch-constituent-history = "market_data.fetch_constituent_history:main"
 market-data-backfill-constituents     = "market_data.fetch_backfill:main"
+market-data-extend-history            = "market_data.fetch_extend_history:main"
 market-data-health              = "market_data.health:main"
 market-data-smoke-test          = "market_data.smoke_test:main"
 

--- a/src/market_data/fetch.py
+++ b/src/market_data/fetch.py
@@ -6,7 +6,9 @@ Core OHLCV fetch and storage logic.
 Functions
 ---------
 fetch_history(symbol, years)        Full historical pull (default 10 years).
+fetch_max_history(symbol)           Full available history via period="max".
 fetch_incremental(symbol, since)    Pull data from a given date onward.
+fetch_date_range(symbol, start, end) Bounded historical pull for a date range.
 save_ticker_data(symbol, df, dir)   Append new rows to per-ticker Parquet,
                                     deduplicating on (date, symbol).
 load_ticker_data(symbol, dir)       Load a per-ticker Parquet (or None).
@@ -96,6 +98,17 @@ def fetch_history(symbol: str, years: int = DEFAULT_HISTORY_YEARS) -> pd.DataFra
     raw = yf.Ticker(symbol).history(
         start=str(start),
         end=str(end),
+        auto_adjust=True,
+        actions=False,
+    )
+    return _normalize(raw, symbol)
+
+
+@yf_retry
+def fetch_max_history(symbol: str) -> pd.DataFrame:
+    """Download the maximum available OHLCV history for *symbol* using period="max"."""
+    raw = yf.Ticker(symbol).history(
+        period="max",
         auto_adjust=True,
         actions=False,
     )

--- a/src/market_data/fetch_extend_history.py
+++ b/src/market_data/fetch_extend_history.py
@@ -1,0 +1,296 @@
+"""
+fetch_extend_history.py
+-----------------------
+Extends OHLCV history for all onboarded active tickers back to the maximum
+available depth (targeting 1990) using yfinance period="max".
+
+For each onboarded ticker whose existing data starts after EARLIEST_TARGET,
+fetches the full available history and merges it into the existing parquet.
+Deduplication is handled by save_ticker_data, so re-runs are safe.
+
+Tickers whose earliest date is already at or before EARLIEST_TARGET are
+marked complete immediately — no network call needed.
+
+Progress state
+--------------
+Two keys are written to state.json after each run:
+
+  extend_history_completed  list[str]       Tickers fully processed.
+  extend_history_failures   dict[str, str]  Tickers that failed; value is reason.
+
+Runs are safe to interrupt and resume: processed tickers are skipped on
+subsequent calls.
+
+CLI: market-data-extend-history
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+import time
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+
+from market_data.config import cfg as _cfg
+from market_data.fetch import fetch_max_history, save_ticker_data
+
+logger = logging.getLogger(__name__)
+
+STATE_FILE = Path(_cfg.get("paths.state_file", "state.json"))
+OHLCV_DIR = Path(_cfg.get("paths.ohlcv_dir", "data/ohlcv"))
+
+EARLIEST_TARGET: date = date(1990, 1, 1)
+DEFAULT_BATCH_SIZE: int = _cfg.get("collection.extend_history_batch_size", 50)
+SLEEP_BETWEEN_CALLS: float = _cfg.get("sources.sleep_between_calls.ohlcv", 5)
+
+
+# ---------------------------------------------------------------------------
+# State helpers
+# ---------------------------------------------------------------------------
+
+def _load_state() -> dict:
+    if STATE_FILE.exists():
+        raw = json.loads(STATE_FILE.read_text())
+    else:
+        raw = {}
+    return {
+        "extend_history_completed": raw.get("extend_history_completed", []),
+        "extend_history_failures": raw.get("extend_history_failures", {}),
+        **{k: v for k, v in raw.items()
+           if k not in {"extend_history_completed", "extend_history_failures"}},
+    }
+
+
+def _save_state(state: dict) -> None:
+    STATE_FILE.write_text(json.dumps(state, indent=2, default=str))
+
+
+# ---------------------------------------------------------------------------
+# Pending-ticker logic
+# ---------------------------------------------------------------------------
+
+def _earliest_date(ticker: str, ohlcv_dir: Path) -> date | None:
+    """Return the earliest date in an existing OHLCV parquet, or None if missing."""
+    path = ohlcv_dir / f"{ticker}.parquet"
+    if not path.exists():
+        return None
+    df = pd.read_parquet(path, columns=["date"])
+    if df.empty:
+        return None
+    return pd.to_datetime(df["date"]).min().date()
+
+
+def pending_tickers(
+    onboarded: set[str],
+    ohlcv_dir: Path,
+    completed: set[str],
+    failures: set[str],
+    earliest_target: date = EARLIEST_TARGET,
+) -> tuple[list[str], list[str]]:
+    """Classify onboarded tickers into those needing extension and those already deep.
+
+    Returns
+    -------
+    (needs_fetch, already_deep)
+        needs_fetch   — tickers whose earliest date is after earliest_target
+        already_deep  — tickers already at or before earliest_target (can be
+                        marked complete without a network call)
+    """
+    needs_fetch: list[str] = []
+    already_deep: list[str] = []
+
+    for ticker in sorted(onboarded):
+        if ticker in completed or ticker in failures:
+            continue
+        earliest = _earliest_date(ticker, ohlcv_dir)
+        if earliest is None:
+            continue  # No file yet; not our job (orchestrator handles onboarding)
+        if earliest <= earliest_target:
+            already_deep.append(ticker)
+        else:
+            needs_fetch.append(ticker)
+
+    return needs_fetch, already_deep
+
+
+# ---------------------------------------------------------------------------
+# Main runner
+# ---------------------------------------------------------------------------
+
+def run(
+    ohlcv_dir: Path = OHLCV_DIR,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    dry_run: bool = False,
+    earliest_target: date = EARLIEST_TARGET,
+) -> dict:
+    """Extend OHLCV history for all onboarded tickers back to earliest_target.
+
+    Parameters
+    ----------
+    ohlcv_dir:
+        Directory where per-ticker OHLCV parquets are stored.
+    batch_size:
+        Maximum number of tickers to fetch in a single run (0 = no limit).
+    dry_run:
+        If True, log what would be fetched without making network calls.
+    earliest_target:
+        Skip tickers whose history already starts at or before this date.
+
+    Returns
+    -------
+    dict with keys ``fetched``, ``skipped``, ``failed``, ``remaining``.
+    """
+    state = _load_state()
+    onboarded: set[str] = set(state.get("onboarded", []))
+    completed: set[str] = set(state["extend_history_completed"])
+    failures: set[str] = set(state["extend_history_failures"].keys())
+
+    if not onboarded:
+        logger.info("No onboarded tickers found in state.json — nothing to do.")
+        return {"fetched": 0, "skipped": 0, "failed": 0, "remaining": 0}
+
+    needs_fetch, already_deep = pending_tickers(
+        onboarded, ohlcv_dir, completed, failures, earliest_target
+    )
+
+    # Mark tickers that already have deep history as complete (no fetch needed)
+    for ticker in already_deep:
+        if ticker not in state["extend_history_completed"]:
+            state["extend_history_completed"].append(ticker)
+    if already_deep:
+        _save_state(state)
+        logger.info(
+            "%d tickers already have history at or before %s — marked complete.",
+            len(already_deep), earliest_target,
+        )
+
+    logger.info(
+        "Extend-history summary: %d onboarded | %d already complete | "
+        "%d failed previously | %d pending fetch",
+        len(onboarded),
+        len(set(state["extend_history_completed"])),
+        len(failures),
+        len(needs_fetch),
+    )
+
+    if not needs_fetch:
+        logger.info("Nothing to extend.")
+        return {
+            "fetched": 0,
+            "skipped": len(already_deep),
+            "failed": 0,
+            "remaining": 0,
+        }
+
+    if batch_size > 0:
+        batch = needs_fetch[:batch_size]
+        remaining = len(needs_fetch) - len(batch)
+    else:
+        batch = needs_fetch
+        remaining = 0
+
+    logger.info(
+        "Processing %d tickers this run%s%s.",
+        len(batch),
+        f" (batch_size={batch_size})" if batch_size > 0 else "",
+        " [DRY RUN]" if dry_run else "",
+    )
+
+    fetched = failed = 0
+
+    for i, ticker in enumerate(batch, 1):
+        if dry_run:
+            logger.info("  [dry-run] %d/%d  %s", i, len(batch), ticker)
+            continue
+
+        logger.info("  %d/%d  %s", i, len(batch), ticker)
+
+        try:
+            df = fetch_max_history(ticker)
+        except Exception as exc:  # noqa: BLE001
+            reason = str(exc)[:200]
+            logger.warning("    FAIL %s: %s", ticker, reason)
+            state["extend_history_failures"][ticker] = reason
+            failed += 1
+            _save_state(state)
+            continue
+
+        if df.empty:
+            reason = "no data returned by yfinance"
+            logger.warning("    SKIP %s: %s", ticker, reason)
+            state["extend_history_failures"][ticker] = reason
+            failed += 1
+            _save_state(state)
+            continue
+
+        new_rows = save_ticker_data(ticker, df, ohlcv_dir)
+        earliest = df["date"].min()
+        logger.info(
+            "    OK   %s: %d rows (%d new, earliest=%s)",
+            ticker, len(df), new_rows, earliest,
+        )
+        state["extend_history_completed"].append(ticker)
+        fetched += 1
+        _save_state(state)
+
+        if i < len(batch):
+            time.sleep(SLEEP_BETWEEN_CALLS)
+
+    if not dry_run:
+        logger.info(
+            "Extend-history run complete: %d fetched, %d failed, %d remaining.",
+            fetched, failed, remaining,
+        )
+
+    return {
+        "fetched": fetched,
+        "skipped": len(already_deep),
+        "failed": failed,
+        "remaining": remaining,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    from market_data.logging_config import setup_logging  # noqa: PLC0415
+    setup_logging()
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Extend OHLCV history for all onboarded tickers back to maximum "
+            "available depth (targeting 1990) using yfinance period='max'."
+        )
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=DEFAULT_BATCH_SIZE,
+        help=(
+            f"Max tickers to fetch per run (default: {DEFAULT_BATCH_SIZE}; "
+            "0 = no limit)"
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Log what would be fetched without making network calls.",
+    )
+    args = parser.parse_args()
+
+    try:
+        run(batch_size=args.batch_size, dry_run=args.dry_run)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Extend-history failed: %s", exc, exc_info=True)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_fetch_extend_history.py
+++ b/tests/test_fetch_extend_history.py
@@ -1,0 +1,262 @@
+"""
+Tests for fetch_extend_history.py:
+  - pending_tickers()  — classification of needs-fetch vs already-deep vs skip
+  - run()              — fetch/save orchestration, state persistence, dry-run,
+                          batch size, already-deep fast-path
+"""
+
+import json
+from datetime import date
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from market_data.fetch_extend_history import pending_tickers, run, EARLIEST_TARGET
+
+
+# ---------------------------------------------------------------------------
+# Fixtures & helpers
+# ---------------------------------------------------------------------------
+
+def _ohlcv(ticker: str, start: str, n: int = 5) -> pd.DataFrame:
+    """Return a minimal OHLCV DataFrame with dates starting at *start*."""
+    dates = pd.date_range(start, periods=n, freq="B").date
+    return pd.DataFrame({
+        "date": dates,
+        "symbol": ticker,
+        "open": 100.0,
+        "high": 105.0,
+        "low": 95.0,
+        "close": 102.0,
+        "volume": 1_000_000.0,
+    })
+
+
+def _write_parquet(path: Path, df: pd.DataFrame) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_parquet(path, index=False)
+
+
+# ---------------------------------------------------------------------------
+# pending_tickers()
+# ---------------------------------------------------------------------------
+
+class TestPendingTickers:
+    def test_ticker_after_target_needs_fetch(self, tmp_path):
+        df = _ohlcv("AAPL", "2015-01-02")
+        _write_parquet(tmp_path / "AAPL.parquet", df)
+        needs, deep = pending_tickers({"AAPL"}, tmp_path, set(), set())
+        assert "AAPL" in needs
+        assert "AAPL" not in deep
+
+    def test_ticker_at_target_is_already_deep(self, tmp_path):
+        df = _ohlcv("AAPL", str(EARLIEST_TARGET))
+        _write_parquet(tmp_path / "AAPL.parquet", df)
+        needs, deep = pending_tickers({"AAPL"}, tmp_path, set(), set())
+        assert "AAPL" not in needs
+        assert "AAPL" in deep
+
+    def test_ticker_before_target_is_already_deep(self, tmp_path):
+        df = _ohlcv("AAPL", "1988-01-04")
+        _write_parquet(tmp_path / "AAPL.parquet", df)
+        needs, deep = pending_tickers({"AAPL"}, tmp_path, set(), set())
+        assert "AAPL" not in needs
+        assert "AAPL" in deep
+
+    def test_completed_ticker_is_skipped(self, tmp_path):
+        df = _ohlcv("AAPL", "2015-01-02")
+        _write_parquet(tmp_path / "AAPL.parquet", df)
+        needs, deep = pending_tickers({"AAPL"}, tmp_path, {"AAPL"}, set())
+        assert needs == []
+        assert deep == []
+
+    def test_failed_ticker_is_skipped(self, tmp_path):
+        df = _ohlcv("AAPL", "2015-01-02")
+        _write_parquet(tmp_path / "AAPL.parquet", df)
+        needs, deep = pending_tickers({"AAPL"}, tmp_path, set(), {"AAPL"})
+        assert needs == []
+        assert deep == []
+
+    def test_ticker_with_no_file_is_skipped(self, tmp_path):
+        needs, deep = pending_tickers({"AAPL"}, tmp_path, set(), set())
+        assert needs == []
+        assert deep == []
+
+    def test_mixed_set_classified_correctly(self, tmp_path):
+        _write_parquet(tmp_path / "SHALLOW.parquet", _ohlcv("SHALLOW", "2018-01-02"))
+        _write_parquet(tmp_path / "DEEP.parquet", _ohlcv("DEEP", "1989-01-03"))
+        _write_parquet(tmp_path / "DONE.parquet", _ohlcv("DONE", "2010-01-04"))
+
+        needs, deep = pending_tickers(
+            {"SHALLOW", "DEEP", "DONE"}, tmp_path, {"DONE"}, set()
+        )
+        assert needs == ["SHALLOW"]
+        assert deep == ["DEEP"]
+
+    def test_custom_earliest_target(self, tmp_path):
+        # Ticker starts in 2010; custom target is 2005 → needs fetching
+        df = _ohlcv("AAPL", "2010-01-04")
+        _write_parquet(tmp_path / "AAPL.parquet", df)
+        custom_target = date(2005, 1, 1)
+        needs, deep = pending_tickers({"AAPL"}, tmp_path, set(), set(), custom_target)
+        assert "AAPL" in needs
+
+
+# ---------------------------------------------------------------------------
+# run()
+# ---------------------------------------------------------------------------
+
+class TestRun:
+    @pytest.fixture()
+    def ohlcv_dir(self, tmp_path) -> Path:
+        d = tmp_path / "ohlcv"
+        d.mkdir()
+        return d
+
+    @pytest.fixture()
+    def state_file(self, tmp_path) -> Path:
+        return tmp_path / "state.json"
+
+    def _base_state(self, tickers: list[str]) -> dict:
+        return {"onboarded": tickers, "extend_history_completed": [], "extend_history_failures": {}}
+
+    @patch("market_data.fetch_extend_history.fetch_max_history")
+    @patch("market_data.fetch_extend_history.save_ticker_data")
+    @patch("market_data.fetch_extend_history.STATE_FILE")
+    def test_fetches_shallow_tickers(
+        self, mock_state_path, mock_save, mock_fetch, ohlcv_dir, tmp_path, state_file
+    ):
+        _write_parquet(ohlcv_dir / "AAPL.parquet", _ohlcv("AAPL", "2015-01-02"))
+
+        state_file.write_text(json.dumps(self._base_state(["AAPL"])))
+        mock_state_path.exists.return_value = True
+        mock_state_path.read_text = state_file.read_text
+        mock_state_path.write_text = state_file.write_text
+
+        mock_fetch.return_value = _ohlcv("AAPL", "1993-01-29", n=100)
+        mock_save.return_value = 80
+
+        result = run(ohlcv_dir=ohlcv_dir, batch_size=0, dry_run=False)
+
+        mock_fetch.assert_called_once_with("AAPL")
+        assert result["fetched"] == 1
+        assert result["failed"] == 0
+
+    @patch("market_data.fetch_extend_history.fetch_max_history")
+    @patch("market_data.fetch_extend_history.save_ticker_data")
+    @patch("market_data.fetch_extend_history.STATE_FILE")
+    def test_deep_tickers_marked_complete_without_fetch(
+        self, mock_state_path, mock_save, mock_fetch, ohlcv_dir, tmp_path, state_file
+    ):
+        _write_parquet(ohlcv_dir / "SPY.parquet", _ohlcv("SPY", "1988-01-04"))
+
+        state_file.write_text(json.dumps(self._base_state(["SPY"])))
+        mock_state_path.exists.return_value = True
+        mock_state_path.read_text = state_file.read_text
+        mock_state_path.write_text = state_file.write_text
+
+        result = run(ohlcv_dir=ohlcv_dir, batch_size=0, dry_run=False)
+
+        mock_fetch.assert_not_called()
+        assert result["skipped"] == 1
+        saved_state = json.loads(state_file.read_text())
+        assert "SPY" in saved_state["extend_history_completed"]
+
+    @patch("market_data.fetch_extend_history.fetch_max_history")
+    @patch("market_data.fetch_extend_history.save_ticker_data")
+    @patch("market_data.fetch_extend_history.STATE_FILE")
+    def test_batch_size_limits_fetches(
+        self, mock_state_path, mock_save, mock_fetch, ohlcv_dir, tmp_path, state_file
+    ):
+        for t in ["AAA", "BBB", "CCC"]:
+            _write_parquet(ohlcv_dir / f"{t}.parquet", _ohlcv(t, "2015-01-02"))
+
+        state_file.write_text(json.dumps(self._base_state(["AAA", "BBB", "CCC"])))
+        mock_state_path.exists.return_value = True
+        mock_state_path.read_text = state_file.read_text
+        mock_state_path.write_text = state_file.write_text
+        mock_fetch.return_value = _ohlcv("AAA", "1993-01-29", n=50)
+        mock_save.return_value = 40
+
+        result = run(ohlcv_dir=ohlcv_dir, batch_size=1, dry_run=False)
+
+        assert mock_fetch.call_count == 1
+        assert result["fetched"] == 1
+        assert result["remaining"] == 2
+
+    @patch("market_data.fetch_extend_history.fetch_max_history")
+    @patch("market_data.fetch_extend_history.save_ticker_data")
+    @patch("market_data.fetch_extend_history.STATE_FILE")
+    def test_empty_data_recorded_as_failure(
+        self, mock_state_path, mock_save, mock_fetch, ohlcv_dir, tmp_path, state_file
+    ):
+        _write_parquet(ohlcv_dir / "AAPL.parquet", _ohlcv("AAPL", "2015-01-02"))
+
+        state_file.write_text(json.dumps(self._base_state(["AAPL"])))
+        mock_state_path.exists.return_value = True
+        mock_state_path.read_text = state_file.read_text
+        mock_state_path.write_text = state_file.write_text
+        mock_fetch.return_value = pd.DataFrame()
+
+        result = run(ohlcv_dir=ohlcv_dir, batch_size=0, dry_run=False)
+
+        assert result["failed"] == 1
+        mock_save.assert_not_called()
+        saved_state = json.loads(state_file.read_text())
+        assert "AAPL" in saved_state["extend_history_failures"]
+
+    @patch("market_data.fetch_extend_history.fetch_max_history")
+    @patch("market_data.fetch_extend_history.save_ticker_data")
+    @patch("market_data.fetch_extend_history.STATE_FILE")
+    def test_dry_run_makes_no_network_calls(
+        self, mock_state_path, mock_save, mock_fetch, ohlcv_dir, tmp_path, state_file
+    ):
+        _write_parquet(ohlcv_dir / "AAPL.parquet", _ohlcv("AAPL", "2015-01-02"))
+
+        state_file.write_text(json.dumps(self._base_state(["AAPL"])))
+        mock_state_path.exists.return_value = True
+        mock_state_path.read_text = state_file.read_text
+        mock_state_path.write_text = state_file.write_text
+
+        run(ohlcv_dir=ohlcv_dir, batch_size=0, dry_run=True)
+
+        mock_fetch.assert_not_called()
+        mock_save.assert_not_called()
+
+    @patch("market_data.fetch_extend_history.fetch_max_history")
+    @patch("market_data.fetch_extend_history.save_ticker_data")
+    @patch("market_data.fetch_extend_history.STATE_FILE")
+    def test_completed_tickers_persisted_to_state(
+        self, mock_state_path, mock_save, mock_fetch, ohlcv_dir, tmp_path, state_file
+    ):
+        _write_parquet(ohlcv_dir / "AAPL.parquet", _ohlcv("AAPL", "2015-01-02"))
+
+        state_file.write_text(json.dumps(self._base_state(["AAPL"])))
+        mock_state_path.exists.return_value = True
+        mock_state_path.read_text = state_file.read_text
+        mock_state_path.write_text = state_file.write_text
+        mock_fetch.return_value = _ohlcv("AAPL", "1993-01-29", n=100)
+        mock_save.return_value = 80
+
+        run(ohlcv_dir=ohlcv_dir, batch_size=0, dry_run=False)
+
+        saved_state = json.loads(state_file.read_text())
+        assert "AAPL" in saved_state["extend_history_completed"]
+
+    @patch("market_data.fetch_extend_history.fetch_max_history")
+    @patch("market_data.fetch_extend_history.save_ticker_data")
+    @patch("market_data.fetch_extend_history.STATE_FILE")
+    def test_no_onboarded_tickers_returns_early(
+        self, mock_state_path, mock_save, mock_fetch, ohlcv_dir, tmp_path, state_file
+    ):
+        state_file.write_text(json.dumps({"onboarded": [], "extend_history_completed": [], "extend_history_failures": {}}))
+        mock_state_path.exists.return_value = True
+        mock_state_path.read_text = state_file.read_text
+        mock_state_path.write_text = state_file.write_text
+
+        result = run(ohlcv_dir=ohlcv_dir, batch_size=0, dry_run=False)
+
+        mock_fetch.assert_not_called()
+        assert result == {"fetched": 0, "skipped": 0, "failed": 0, "remaining": 0}


### PR DESCRIPTION
## Summary
- Adds `fetch_max_history()` to `fetch.py` using yfinance `period="max"`
- New `fetch_extend_history.py` module + `market-data-extend-history` CLI: iterates all onboarded active tickers, checks the earliest date on disk, fetches full history for any ticker with data starting after 1990-01-01, and merges atomically via `save_ticker_data`
- Tickers already at or before the 1990 target are marked complete immediately (no network call); progress is persisted to `state.json` so runs are safely resumable with `--batch-size` and `--dry-run` support

Closes #6

## Test plan
- [ ] `market-data-extend-history --dry-run` to verify scope before running
- [ ] `market-data-extend-history --batch-size 50` to run in batches
- [ ] Verify `state.json` updates `extend_history_completed` after each batch
- [ ] Re-run confirms already-completed tickers are skipped with no network calls
- [ ] 514 tests passing, no regressions